### PR TITLE
Fix event queue readiness wakeups

### DIFF
--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -123,7 +123,8 @@ EventQueue::loop()
         }
 
         *m_readyCondVar = true;
-        m_readyCondVar->signal();
+        // Readiness is a sticky state, so every current waiter can proceed.
+        m_readyCondVar->broadcast();
     }
     LOG((CLOG_DEBUG "event queue is ready"));
 

--- a/src/lib/base/EventQueue.cpp
+++ b/src/lib/base/EventQueue.cpp
@@ -88,7 +88,8 @@ EventQueue::EventQueue() :
     m_typesForClipboard(NULL),
     m_typesForFile(NULL),
     m_readyMutex(new Mutex),
-    m_readyCondVar(new CondVar<bool>(m_readyMutex, false))
+    m_readyCondVar(new CondVar<bool>(m_readyMutex, false)),
+    m_readyWaiterCount(0)
 {
     ARCH->setSignalHandler(Arch::kINTERRUPT, &interrupt, this);
     ARCH->setSignalHandler(Arch::kTERMINATE, &interrupt, this);
@@ -588,9 +589,20 @@ EventQueue::waitForReady() const
     Lock lock(m_readyMutex);
 
     // Test the stored predicate before waiting so callers arriving after the
-    // one startup signal return immediately instead of blocking forever.
+    // startup transition return immediately instead of blocking forever.
     while (!(*m_readyCondVar)) {
-        if (!m_readyCondVar->wait(timer, 10.0)) {
+        ++m_readyWaiterCount;
+        bool signaled = false;
+        try {
+            signaled = m_readyCondVar->wait(timer, 10.0);
+        }
+        catch (...) {
+            --m_readyWaiterCount;
+            throw;
+        }
+        --m_readyWaiterCount;
+
+        if (!signaled) {
             throw std::runtime_error("event queue is not ready within 10 sec");
         }
     }

--- a/src/lib/base/EventQueue.h
+++ b/src/lib/base/EventQueue.h
@@ -31,12 +31,18 @@
 #include <mutex>
 #include <queue>
 
+namespace barrier_test {
+class EventQueueTestAccess;
+}
+
 //! Event queue
 /*!
 An event queue that implements the platform independent parts and
 delegates the platform dependent parts to a subclass.
 */
 class EventQueue : public IEventQueue {
+    friend class barrier_test::EventQueueTestAccess;
+
 public:
     EventQueue();
     virtual ~EventQueue();
@@ -182,6 +188,7 @@ private:
     FileEvents*                    m_typesForFile;
     Mutex*                        m_readyMutex;
     CondVar<bool>*                m_readyCondVar;
+    mutable UInt32                m_readyWaiterCount;
     std::queue<Event>            m_pending;
     NonBlockingStream            m_parentStream;
 };

--- a/src/test/unittests/base/EventQueueTests.cpp
+++ b/src/test/unittests/base/EventQueueTests.cpp
@@ -20,6 +20,17 @@
 
 namespace {
 
+bool waitForThreadOrCancel(Thread& thread, double timeout)
+{
+    if (thread.wait(timeout)) {
+        return true;
+    }
+
+    thread.cancel();
+    thread.wait();
+    return false;
+}
+
 class BlockingFirstAddBuffer : public SimpleEventQueueBuffer {
 public:
     BlockingFirstAddBuffer() :
@@ -133,11 +144,11 @@ TEST_F(EventQueueStartupTests, BecomesReadyOnlyAfterPendingEventsReachBuffer)
     {
         std::unique_lock<std::mutex> lock(readyMutex);
         EXPECT_TRUE(readyCondition.wait_for(
-            lock, std::chrono::seconds(1),
+            lock, std::chrono::seconds(10),
             [&waitForReadyReturned] { return waitForReadyReturned; }));
     }
-    EXPECT_TRUE(readyThread.wait(1.0));
-    EXPECT_TRUE(loopThread.wait(1.0));
+    EXPECT_TRUE(waitForThreadOrCancel(readyThread, 10.0));
+    EXPECT_TRUE(waitForThreadOrCancel(loopThread, 10.0));
 
     EXPECT_TRUE(m_delivered);
 }

--- a/src/test/unittests/base/EventQueueTests.cpp
+++ b/src/test/unittests/base/EventQueueTests.cpp
@@ -10,6 +10,7 @@
 #include "base/EventQueue.h"
 #include "base/SimpleEventQueueBuffer.h"
 #include "base/TMethodEventJob.h"
+#include "mt/Lock.h"
 #include "mt/Thread.h"
 
 #include <gtest/gtest.h>
@@ -17,8 +18,18 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <thread>
 
-namespace {
+namespace barrier_test {
+
+class EventQueueTestAccess {
+public:
+    static UInt32 readyWaiterCount(const EventQueue& events)
+    {
+        Lock lock(events.m_readyMutex);
+        return events.m_readyWaiterCount;
+    }
+};
 
 bool waitForThreadOrCancel(Thread& thread, double timeout)
 {
@@ -29,6 +40,21 @@ bool waitForThreadOrCancel(Thread& thread, double timeout)
     thread.cancel();
     thread.wait();
     return false;
+}
+
+bool waitForReadyWaiters(const EventQueue& events, UInt32 expected,
+    std::chrono::seconds timeout)
+{
+    const std::chrono::steady_clock::time_point deadline =
+        std::chrono::steady_clock::now() + timeout;
+    do {
+        if (EventQueueTestAccess::readyWaiterCount(events) >= expected) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    return EventQueueTestAccess::readyWaiterCount(events) >= expected;
 }
 
 class BlockingFirstAddBuffer : public SimpleEventQueueBuffer {
@@ -153,4 +179,37 @@ TEST_F(EventQueueStartupTests, BecomesReadyOnlyAfterPendingEventsReachBuffer)
     EXPECT_TRUE(m_delivered);
 }
 
-} // namespace
+TEST_F(EventQueueStartupTests, WakesAllCallersAlreadyWaitingForReady)
+{
+    std::mutex returnedMutex;
+    std::condition_variable returnedCondition;
+    UInt32 returnedCount = 0;
+    const std::function<void()> waitForReady = [this, &returnedMutex,
+        &returnedCondition, &returnedCount] {
+        m_events.waitForReady();
+        std::lock_guard<std::mutex> lock(returnedMutex);
+        ++returnedCount;
+        returnedCondition.notify_all();
+    };
+
+    Thread firstWaiter(waitForReady);
+    Thread secondWaiter(waitForReady);
+    EXPECT_TRUE(waitForReadyWaiters(
+        m_events, 2, std::chrono::seconds(10)));
+
+    m_events.addEvent(Event(Event::kQuit));
+    Thread loopThread([this] { m_events.loop(); });
+
+    {
+        std::unique_lock<std::mutex> lock(returnedMutex);
+        EXPECT_TRUE(returnedCondition.wait_for(
+            lock, std::chrono::seconds(10),
+            [&returnedCount] { return returnedCount == 2; }));
+    }
+
+    EXPECT_TRUE(waitForThreadOrCancel(firstWaiter, 10.0));
+    EXPECT_TRUE(waitForThreadOrCancel(secondWaiter, 10.0));
+    EXPECT_TRUE(waitForThreadOrCancel(loopThread, 10.0));
+}
+
+} // namespace barrier_test


### PR DESCRIPTION
## Summary

- broadcast the sticky event-queue ready transition to every current waiter
- add a deterministic two-waiter regression that proves both callers are parked before readiness changes
- give startup regressions their documented readiness window
- cancel and join overdue test threads before fixture state is destroyed

## Verification

- all startup regressions: 500 repetitions
- negative control: the two-waiter regression rejects the former single-signal behavior
- core unit tests: 309 passed
- GUI unit tests: 226 passed
- release-verifier tests and public audit passed

Closes #44