### PR TITLE
Complete the 3.4.0 release and feature history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ snapshots and release documentation; see
   immediately, and suppressed repeated identical service-resolution logs.
 - Added checksum-pinned macOS dependencies, complete Mach-O deployment-target
   checks, and release privacy audits.
+- Woke every caller waiting for event-queue readiness when startup completed.
 
 ## 3.3.1 — 2026-08-29
 
@@ -43,8 +44,8 @@ snapshots and release documentation; see
   adjacent screens retain their intended links.
 - Corrected partial-edge coordinate mapping and prevented the cursor from
   bouncing back to the source screen.
-- Improved how client display rectangles are represented in the freeform
-  layout.
+- Improved freeform display-rectangle handling for portrait displays, multiple
+  displays, and multiple simultaneously connected clients.
 
 ## 3.3.0 — 2026-08-29
 
@@ -68,6 +69,10 @@ Status: draft, superseded by later releases.
 - Improved input in login sessions, perceived scroll direction across hosts,
   and activation of menu-bar windows.
 - Added forwarding for Magic Mouse two-finger Spaces gestures.
+- Fixed cross-platform HTML clipboard encoding, restored Windows display
+  scaling above 100%, and fixed GCC 11.2 builds.
+- Improved incompatible-macOS launch guidance, updated Japanese translations,
+  and refreshed OS-support and Linux drag-and-drop guidance.
 
 ## 2.4.0 — 2021-11-01
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ details, see the [upstream Barrier repository](https://github.com/debauchee/barr
 
 ## Download
 
-- Use the [GitHub Releases](https://github.com/ibetterai/barrier/releases)
-  section to download the latest Apple Silicon macOS build or a previous build.
+- Use [GitHub Releases](https://github.com/ibetterai/barrier/releases) to
+  download the latest Apple Silicon macOS build and view reconstructed notes
+  for earlier releases.
 - See the [changelog](CHANGELOG.md) and
   [feature and fix ledger](docs/history/feature-fix-ledger.md) for the
   reconstructed public product history.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ details, see the [upstream Barrier repository](https://github.com/debauchee/barr
 
 ## Download
 
-- Use [GitHub Releases](https://github.com/ibetterai/barrier/releases) to
-  download the latest Apple Silicon macOS build and view reconstructed notes
-  for earlier releases.
+- Use [GitHub Releases](https://github.com/ibetterai/barrier/releases) to view
+  reconstructed notes. Apple Silicon DMGs appear there when a release includes
+  a verified binary asset.
 - See the [changelog](CHANGELOG.md) and
   [feature and fix ledger](docs/history/feature-fix-ledger.md) for the
   reconstructed public product history.
 
-Barrier 3.4.0 and later packages from this fork target Apple Silicon and macOS
-12 or later. These packages are Developer ID signed, Apple notarized, and
-stapled for offline Gatekeeper verification.
+Release candidates for Barrier 3.4.0 and later target Apple Silicon and macOS
+12 or later. Before attaching a DMG, verify its Developer ID signature, Apple
+notarization ticket, stapling, and offline Gatekeeper acceptance.
 
 ## What this fork adds
 

--- a/doc/release_notes/index.md
+++ b/doc/release_notes/index.md
@@ -41,6 +41,8 @@ Bug fixes
 - Fixed Apple Silicon release packaging so Qt and OpenSSL come from checksum-pinned sources built
   for macOS 12, every bundled Mach-O file is audited before signing, and release checks reject
   local home paths and concrete private IPv4 addresses from tracked text sources and final app bundles.
+- Fixed event-queue startup readiness so all callers already waiting are released when
+  initialization completes.
 
 Barrier `3.3.1` ( `2026-08-29` )
 ================================
@@ -52,7 +54,8 @@ Bug fixes
   their intended links.
 - Corrected partial-edge coordinate mapping so the pointer does not bounce back to the source
   screen.
-- Improved client display-rectangle representation in the freeform layout.
+- Improved freeform display-rectangle handling for portrait displays, multiple displays, and
+  multiple simultaneously connected clients.
 
 Barrier `3.3.0` ( `2026-08-29` )
 ================================
@@ -75,6 +78,10 @@ Features and fixes
   routing.
 - Added client display wake-on-entry, layout persistence, reliable login-session input, consistent
   scrolling, menu activation fixes, and Magic Mouse Spaces gesture forwarding.
+- Fixed cross-platform HTML clipboard encoding, restored Windows display scaling above 100%, and
+  fixed GCC 11.2 builds.
+- Improved incompatible-macOS launch guidance, updated Japanese translations, and refreshed
+  OS-support and Linux drag-and-drop guidance.
 
 Barrier `2.4.0` ( `2021-11-01` )
 ================================

--- a/docs/history/feature-fix-ledger.md
+++ b/docs/history/feature-fix-ledger.md
@@ -19,18 +19,20 @@ IDs describe product behavior; they are not links to legacy tracker objects.
 | H-012 | 2026-08-29 | Compatibility | Rectangular fallback for older peers | Shipped | 3.3.0 |
 | H-013 | 2026-08-29 | Fix | Freeform coordinate-rounding gap tolerance | Shipped | 3.3.1 |
 | H-014 | 2026-08-29 | Fix | Partial-edge coordinate mapping without cursor bounce | Shipped | 3.3.1 |
-| H-015 | 2026-08-29 | Fix | Improved client display-rectangle representation | Shipped | 3.3.1 |
+| H-015 | 2026-08-29 | Fix | Freeform display-rectangle handling for portrait and multi-display clients, including multiple simultaneous connections | Shipped | 3.3.1 |
 | H-016 | 2026-08-31 | Feature | Exact display-topology profiles | Shipped | 3.4.0 |
 | H-017 | 2026-08-31 | Safety | Switching pause for unknown display topologies | Shipped | 3.4.0 |
 | H-018 | 2026-08-31 | Feature | Paired Bluetooth and Bonjour proximity gating | Shipped | 3.4.0 |
 | H-019 | 2026-08-31 | Feature | User-adjustable signal thresholds with hysteresis | Shipped | 3.4.0 |
 | H-020 | 2026-08-31 | Feature | Optional pair-scoped client signal sharing | Shipped | 3.4.0 |
 | H-021 | 2026-08-31 | Feature | Rate-limited network wake for offline clients | Shipped | 3.4.0 |
-| H-022 | 2026-08-31 | Fix | Immediate recovery after topology and sleep transitions | Shipped | 3.4.0 |
-| H-023 | 2026-08-31 | Fix | Main-run-loop event capture and disabled-tap recovery | Shipped | 3.4.0 |
+| H-022 | 2026-08-31 | Fix | Automatic client reconnection after topology-driven server reloads | Shipped | 3.4.0 |
+| H-023 | 2026-08-31 | Fix | Pointer transfer after macOS sleep/wake through main-run-loop event capture and disabled-tap recovery | Shipped | 3.4.0 |
 | H-024 | 2026-08-31 | Fix | Manual server address precedence when Auto config is off | Shipped | 3.4.0 |
 | H-025 | 2026-08-31 | Fix | Deduplicated service-resolution snapshots and endpoint logs | Shipped | 3.4.0 |
 | H-026 | 2026-08-31 | Release | Pinned dependencies, deployment checks, and privacy audits | Shipped | 3.4.0 |
+| H-027 | 2026-08-31 | Fix | Preserved paired discovery metadata, selected routable server endpoints, and rejected auxiliary discovery endpoints | Shipped | 3.4.0 |
+| H-028 | 2026-08-31 | Fix | Event-queue readiness wakes every caller already waiting at startup | Shipped | 3.4.0 |
 
 Upstream history before this fork is retained in the source-tree changelogs and
 release notes.

--- a/docs/history/source-provenance.md
+++ b/docs/history/source-provenance.md
@@ -2,11 +2,12 @@
 
 The public version history in this repository is reconstructed from audited
 source snapshots. Each retained version has a new commit with neutral metadata
-and an accurate source tree, followed by a tag that points to that version.
+and an audited, functionally equivalent product-source snapshot, followed by a
+tag that points to that version.
 
-The reconstruction preserves source code, file modes, public submodule pins,
-licenses, and upstream attribution. It also applies narrowly scoped public
-hygiene changes:
+The reconstruction preserves product source code, file modes, public submodule
+pins, licenses, and upstream attribution. It also applies narrowly scoped
+public hygiene changes:
 
 - support instructions use the public issue tracker;
 - documentation examples use neutral paths and addresses;
@@ -22,5 +23,6 @@ reconstructed repository. Historical commit dates therefore reflect the
 reconstruction; the changelog records the original release dates and status.
 
 The 3.2.0 record remains a draft that was superseded. The 3.3.0 and 3.3.1
-records are published releases. The 2.4.0 record is an annotated upstream tag
-baseline rather than a reconstructed binary release.
+records are published releases. The 2.4.0 record is a reconstructed source
+baseline corresponding to the upstream release, marked by a new annotated tag;
+no binary release is reconstructed.


### PR DESCRIPTION
## Summary

- finalize the 3.4.0 README and release notes
- preserve reconstructed feature and bug-fix history through 2.4.0
- clarify source-snapshot provenance and historical release status
- record the event-queue startup readiness fix

## Verification

- documentation surface/version and ledger continuity checks passed
- public privacy audit passed
- diff is limited to five public documentation files

Closes #35