### PR TITLE
Expose privacy-safe release build diagnostics

### DIFF
--- a/.github/workflows/ci-local.yml
+++ b/.github/workflows/ci-local.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           scripts/tests/scan-protected-metadata_test.sh
           scripts/tests/build-macos-release-prefix_diagnostics_test.sh
+          scripts/tests/sanitize-release-build-log_test.sh
           scripts/tests/verify-macos-deployment-target_test.sh
           scripts/tests/public-audit_test.sh
 

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -131,6 +131,14 @@ jobs:
           if ! "$cmake_bin" --build "$RELEASE_BUILD_DIR" --parallel 3 \
               >"$build_log" 2>&1; then
             echo 'locked release build failed' >&2
+            if ! /usr/bin/python3 scripts/sanitize-release-build-log.py \
+                "$build_log" \
+                --source-root "$GITHUB_WORKSPACE" \
+                --build-root "$RELEASE_BUILD_DIR" \
+                --prefix-root "$RELEASE_PREFIX" \
+                --temp-root "$RUNNER_TEMP"; then
+              echo 'privacy-safe build diagnostics unavailable' >&2
+            fi
             exit 1
           fi
           if grep -Eiq \

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -131,12 +131,18 @@ jobs:
           if ! "$cmake_bin" --build "$RELEASE_BUILD_DIR" --parallel 3 \
               >"$build_log" 2>&1; then
             echo 'locked release build failed' >&2
-            if ! /usr/bin/python3 scripts/sanitize-release-build-log.py \
+            diagnostic_output="$RUNNER_TEMP/release-product-build.sanitized"
+            if /usr/bin/python3 scripts/sanitize-release-build-log.py \
                 "$build_log" \
                 --source-root "$GITHUB_WORKSPACE" \
                 --build-root "$RELEASE_BUILD_DIR" \
                 --prefix-root "$RELEASE_PREFIX" \
-                --temp-root "$RUNNER_TEMP"; then
+                --temp-root "$RUNNER_TEMP" \
+                >"$diagnostic_output" 2>/dev/null \
+                && /usr/bin/perl scripts/scan-protected-metadata.pl \
+                  --source-path "$diagnostic_output" >/dev/null 2>&1; then
+              /bin/cat "$diagnostic_output"
+            else
               echo 'privacy-safe build diagnostics unavailable' >&2
             fi
             exit 1

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -131,18 +131,12 @@ jobs:
           if ! "$cmake_bin" --build "$RELEASE_BUILD_DIR" --parallel 3 \
               >"$build_log" 2>&1; then
             echo 'locked release build failed' >&2
-            diagnostic_output="$RUNNER_TEMP/release-product-build.sanitized"
-            if /usr/bin/python3 scripts/sanitize-release-build-log.py \
+            if ! scripts/emit-sanitized-release-diagnostics.sh \
                 "$build_log" \
-                --source-root "$GITHUB_WORKSPACE" \
-                --build-root "$RELEASE_BUILD_DIR" \
-                --prefix-root "$RELEASE_PREFIX" \
-                --temp-root "$RUNNER_TEMP" \
-                >"$diagnostic_output" 2>/dev/null \
-                && /usr/bin/perl scripts/scan-protected-metadata.pl \
-                  --source-path "$diagnostic_output" >/dev/null 2>&1; then
-              /bin/cat "$diagnostic_output"
-            else
+                "$GITHUB_WORKSPACE" \
+                "$RELEASE_BUILD_DIR" \
+                "$RELEASE_PREFIX" \
+                "$RUNNER_TEMP"; then
               echo 'privacy-safe build diagnostics unavailable' >&2
             fi
             exit 1

--- a/scripts/emit-sanitized-release-diagnostics.sh
+++ b/scripts/emit-sanitized-release-diagnostics.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+    exit 2
+fi
+
+build_log=$1
+source_root=$2
+build_root=$3
+prefix_root=$4
+runner_temp=$5
+
+if ! script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd); then
+    exit 2
+fi
+sanitizer="$script_dir/sanitize-release-build-log.py"
+metadata_scanner="$script_dir/scan-protected-metadata.pl"
+if [ ! -f "$sanitizer" ] || [ ! -f "$metadata_scanner" ] \
+    || [ ! -d "$runner_temp" ]; then
+    exit 2
+fi
+
+diagnostic_output=
+cleanup() {
+    if [ -n "$diagnostic_output" ]; then
+        /bin/rm -f "$diagnostic_output"
+    fi
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+if ! diagnostic_output=$(/usr/bin/mktemp \
+    "$runner_temp/barrier-release-diagnostics.XXXXXX" 2>/dev/null); then
+    exit 2
+fi
+
+if ! /usr/bin/python3 "$sanitizer" \
+    "$build_log" \
+    --source-root "$source_root" \
+    --build-root "$build_root" \
+    --prefix-root "$prefix_root" \
+    --temp-root "$runner_temp" \
+    >"$diagnostic_output" 2>/dev/null; then
+    exit 1
+fi
+if ! /usr/bin/perl "$metadata_scanner" \
+    --source "$diagnostic_output" >/dev/null 2>&1; then
+    exit 1
+fi
+
+/bin/cat "$diagnostic_output"

--- a/scripts/sanitize-release-build-log.py
+++ b/scripts/sanitize-release-build-log.py
@@ -59,7 +59,8 @@ MAC_ADDRESS = re.compile(r"(?i)(?<![0-9a-f])(?:[0-9a-f]{2}:){5}[0-9a-f]{2}(?![0-
 SENSITIVE_TERM = re.compile(
     r"(?i)(?:^|[^A-Za-z0-9])(?:[A-Za-z0-9_-]*"
     r"(?:token|secret|password|passwd|authorization|credential|cookie|"
-    r"private[_-]?key|access[_-]?key)[A-Za-z0-9_-]*)(?:[^A-Za-z0-9]|$)"
+    r"private[_-]?key|access[_-]?key|api[_-]?key|bearer)"
+    r"[A-Za-z0-9_-]*)(?:[^A-Za-z0-9]|$)"
 )
 OPAQUE_VALUE = re.compile(r"(?<![A-Za-z0-9_])[A-Za-z0-9_+/=-]{32,}(?![A-Za-z0-9_])")
 SAFE_ARCH = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
@@ -70,9 +71,9 @@ SAFE_LOCATION_OUTPUT = (
 )
 ALLOWED_DETAIL = re.compile(
     rf"^\| (?:compiler (?:fatal )?error at (?:{SAFE_LOCATION_OUTPUT}):"
-    r"[0-9]+(?::[0-9]+)?: [ -~]+|"
+    r"[0-9]+(?::[0-9]+)?|"
     rf"cmake error at (?:{SAFE_LOCATION_OUTPUT}):[0-9]+|"
-    r"compiler driver error: [ -~]+|"
+    r"compiler driver error: command failed|"
     r"linker error: (?:command failed|undefined symbols for architecture [A-Za-z0-9_-]{1,32})|"
     r"build tool error: command failed|autogen error: subprocess failed)$"
 )
@@ -160,28 +161,6 @@ def normalize_location(raw_path: str, replacements) -> str:
     return "<relative-path>"
 
 
-def sanitize_message(raw_message: str, replacements) -> str:
-    message = strip_controls(raw_message.strip())
-    if not message:
-        return "<message-unavailable>"
-    if PEM_BEGIN.search(message) or PEM_END.search(message) or SENSITIVE_TERM.search(message):
-        return "<redacted-sensitive-message>"
-
-    for root, label in replacements:
-        message = message.replace(root, label)
-    message = URL.sub("<url>", message)
-    message = UNC_PATH.sub("<external-path>", message)
-    message = WINDOWS_PATH.sub("<external-path>", message)
-    message = TILDE_PATH.sub("<external-path>", message)
-    message = POSIX_ABSOLUTE_PATH.sub("<external-path>", message)
-    message = IPV4_ADDRESS.sub("<network-address>", message)
-    message = IPV6_ADDRESS.sub("<network-address>", message)
-    message = MAC_ADDRESS.sub("<network-address>", message)
-    message = OPAQUE_VALUE.sub("<redacted-value>", message)
-    message = re.sub(r"\s+", " ", message).strip()
-    return message or "<message-unavailable>"
-
-
 def structured_diagnostic(line: str, replacements):
     match = COMPILER_DIAGNOSTIC.match(line)
     if match:
@@ -191,8 +170,7 @@ def structured_diagnostic(line: str, replacements):
         if column:
             line_number = f"{line_number}:{column}"
         severity = match.group("severity").lower()
-        message = sanitize_message(match.group("message"), replacements)
-        return f"compiler {severity} at {location}:{line_number}: {message}"
+        return f"compiler {severity} at {location}:{line_number}"
 
     match = CMAKE_DIAGNOSTIC.match(line)
     if match:
@@ -201,8 +179,7 @@ def structured_diagnostic(line: str, replacements):
 
     match = COMPILER_DRIVER_DIAGNOSTIC.match(line)
     if match:
-        message = sanitize_message(match.group("message"), replacements)
-        return f"compiler driver error: {message}"
+        return "compiler driver error: command failed"
 
     match = UNDEFINED_SYMBOLS.match(line)
     if match and SAFE_ARCH.fullmatch(match.group("arch")):

--- a/scripts/sanitize-release-build-log.py
+++ b/scripts/sanitize-release-build-log.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+"""Emit bounded, privacy-safe diagnostics from a hosted release build log."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
+CONTROL_CHARACTER = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+HOME_PATH = re.compile(r"(?<![A-Za-z0-9])/(?:Users|home)/[^\s:'\"]+")
+TEMP_PATH = re.compile(r"(?<![A-Za-z0-9])/(?:private/)?(?:tmp|var/folders)/[^\s:'\"]+")
+PRIVATE_IPV4 = re.compile(
+    r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|"
+    r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b"
+)
+PRIVATE_IPV6 = re.compile(r"(?i)\b(?:f[cd][0-9a-f]{2}|fe8[0-9a-f]):[0-9a-f:]+\b")
+SENSITIVE_ASSIGNMENT = re.compile(
+    r"(?i)\b(token|password|secret|authorization|api[_-]?key)"
+    r"(\s*[:=]\s*)([^\s]+)"
+)
+KNOWN_TOKEN = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{16,})\b")
+URL_USERINFO = re.compile(r"(https?://)[^/@\s:]+:[^/@\s]+@")
+KEY_MATERIAL = re.compile(r"-----BEGIN [A-Z0-9 ]*(?:PRIVATE KEY|CERTIFICATE)-----")
+ERROR_MARKER = re.compile(r"(?i)\b(?:error|fatal|failed|undefined symbol|not found)\b")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("log_path")
+    parser.add_argument("--source-root")
+    parser.add_argument("--build-root")
+    parser.add_argument("--prefix-root")
+    parser.add_argument("--temp-root")
+    parser.add_argument("--max-lines", type=int, default=120)
+    return parser.parse_args()
+
+
+def root_replacements(args: argparse.Namespace):
+    candidates = (
+        (args.source_root, "barrier-source"),
+        (args.build_root, "barrier-build"),
+        (args.prefix_root, "barrier-prefix"),
+        (args.temp_root, "runner-temp"),
+    )
+    replacements = []
+    for raw_path, label in candidates:
+        if not raw_path:
+            continue
+        path = str(Path(raw_path).expanduser()).rstrip("/")
+        if path:
+            replacements.append((path, label))
+    return sorted(replacements, key=lambda item: len(item[0]), reverse=True)
+
+
+def sanitize(line: str, replacements) -> str:
+    line = ANSI_ESCAPE.sub("", line)
+    line = CONTROL_CHARACTER.sub("", line)
+    for path, label in replacements:
+        line = line.replace(path, label)
+    line = HOME_PATH.sub("<home-path>", line)
+    line = TEMP_PATH.sub("<temp-path>", line)
+    line = PRIVATE_IPV4.sub("<private-address>", line)
+    line = PRIVATE_IPV6.sub("<private-address>", line)
+    line = SENSITIVE_ASSIGNMENT.sub(lambda match: f"{match.group(1)}=<redacted>", line)
+    line = KNOWN_TOKEN.sub("<redacted-token>", line)
+    line = URL_USERINFO.sub(r"\1<redacted>@", line)
+    if KEY_MATERIAL.search(line):
+        line = "<redacted-key-material>"
+    return line.rstrip()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.max_lines < 1 or args.max_lines > 500:
+        print("release-build-diagnostics: invalid line bound", file=sys.stderr)
+        return 2
+
+    try:
+        raw_lines = Path(args.log_path).read_text(errors="replace").splitlines()
+    except OSError:
+        print("release-build-diagnostics: log unavailable", file=sys.stderr)
+        return 2
+
+    replacements = root_replacements(args)
+    sanitized = [sanitize(line, replacements) for line in raw_lines]
+    sanitized = [line for line in sanitized if line]
+    emitted = sanitized[-args.max_lines :]
+    error_markers = sum(1 for line in sanitized if ERROR_MARKER.search(line))
+
+    print("release-build-diagnostics: sanitized tail")
+    print(f"total_lines={len(raw_lines)}")
+    print(f"emitted_lines={len(emitted)}")
+    print(f"error_markers={error_markers}")
+    for line in emitted:
+        print(f"| {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sanitize-release-build-log.py
+++ b/scripts/sanitize-release-build-log.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Emit bounded, privacy-safe diagnostics from a hosted release build log."""
+"""Emit bounded, privacy-safe structured diagnostics from a release build log."""
 
 import argparse
 import re
@@ -10,21 +10,72 @@ from pathlib import Path
 
 ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
 CONTROL_CHARACTER = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-HOME_PATH = re.compile(r"(?<![A-Za-z0-9])/(?:Users|home)/[^\s:'\"]+")
-TEMP_PATH = re.compile(r"(?<![A-Za-z0-9])/(?:private/)?(?:tmp|var/folders)/[^\s:'\"]+")
-PRIVATE_IPV4 = re.compile(
-    r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|"
-    r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b"
+COMPILER_DIAGNOSTIC = re.compile(
+    r"^(?P<path>.+?):(?P<line>[0-9]+)(?::(?P<column>[0-9]+))?:\s*"
+    r"(?P<severity>fatal error|error):\s*(?P<message>.*)$",
+    re.IGNORECASE,
 )
-PRIVATE_IPV6 = re.compile(r"(?i)\b(?:f[cd][0-9a-f]{2}|fe8[0-9a-f]):[0-9a-f:]+\b")
-SENSITIVE_ASSIGNMENT = re.compile(
-    r"(?i)\b(token|password|secret|authorization|api[_-]?key)"
-    r"(\s*[:=]\s*)([^\s]+)"
+CMAKE_DIAGNOSTIC = re.compile(
+    r"^CMake Error at (?P<path>.+?):(?P<line>[0-9]+)(?:\s+\([^)]*\))?:?",
+    re.IGNORECASE,
 )
-KNOWN_TOKEN = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{16,})\b")
-URL_USERINFO = re.compile(r"(https?://)[^/@\s:]+:[^/@\s]+@")
-KEY_MATERIAL = re.compile(r"-----BEGIN [A-Z0-9 ]*(?:PRIVATE KEY|CERTIFICATE)-----")
-ERROR_MARKER = re.compile(r"(?i)\b(?:error|fatal|failed|undefined symbol|not found)\b")
+COMPILER_DRIVER_DIAGNOSTIC = re.compile(
+    r"^(?:apple )?(?P<tool>clang(?:\+\+)?|cc|c\+\+|ld):\s*"
+    r"(?:fatal\s+)?error:\s*(?P<message>.*)$",
+    re.IGNORECASE,
+)
+UNDEFINED_SYMBOLS = re.compile(
+    r"^Undefined symbols for architecture (?P<arch>[A-Za-z0-9_-]{1,32}):?$",
+    re.IGNORECASE,
+)
+LINKER_NOT_FOUND = re.compile(
+    r"^(?:ld|clang(?:\+\+)?):.*(?:symbol\(s\) not found|linker command failed)",
+    re.IGNORECASE,
+)
+BUILD_TOOL_FAILURE = re.compile(
+    r"^(?:ninja: build stopped: subcommand failed\.?|"
+    r"(?:g?make|make)(?:\[[0-9]+\])?: \*\*\* .*Error [0-9]+)$",
+    re.IGNORECASE,
+)
+AUTOGEN_FAILURE = re.compile(
+    r"^(?:AutoMoc|AutoUic|AutoRcc)(?: subprocess)? error", re.IGNORECASE
+)
+PEM_BEGIN = re.compile(r"-----BEGIN [^-]+-----", re.IGNORECASE)
+PEM_END = re.compile(r"-----END [^-]+-----", re.IGNORECASE)
+URL = re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s'\"<>]+", re.IGNORECASE)
+WINDOWS_PATH = re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s'\"<>|]+")
+UNC_PATH = re.compile(r"\\\\[^\s\\/]+[\\/][^\s'\"<>|]+")
+POSIX_ABSOLUTE_PATH = re.compile(r"(?<![A-Za-z0-9_.-])/(?:[^/\s'\"<>|][^\s'\"<>|]*)")
+TILDE_PATH = re.compile(r"(?<![A-Za-z0-9])~[/\\][^\s'\"<>|]+")
+IPV4_ADDRESS = re.compile(
+    r"(?<![0-9.])(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})"
+    r"(?:\.(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})){3}(?![0-9.])"
+)
+IPV6_ADDRESS = re.compile(
+    r"(?i)(?<![0-9a-f:])(?:(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|"
+    r"[0-9a-f:]*::[0-9a-f:]*)(?![0-9a-f:])"
+)
+MAC_ADDRESS = re.compile(r"(?i)(?<![0-9a-f])(?:[0-9a-f]{2}:){5}[0-9a-f]{2}(?![0-9a-f])")
+SENSITIVE_TERM = re.compile(
+    r"(?i)(?:^|[^A-Za-z0-9])(?:[A-Za-z0-9_-]*"
+    r"(?:token|secret|password|passwd|authorization|credential|cookie|"
+    r"private[_-]?key|access[_-]?key)[A-Za-z0-9_-]*)(?:[^A-Za-z0-9]|$)"
+)
+OPAQUE_VALUE = re.compile(r"(?<![A-Za-z0-9_])[A-Za-z0-9_+/=-]{32,}(?![A-Za-z0-9_])")
+SAFE_ARCH = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+SAFE_RELATIVE_PATH = re.compile(r"^[A-Za-z0-9._+/@~-]+$")
+SAFE_LOCATION_OUTPUT = (
+    r"(?:barrier-(?:source|build|prefix)|runner-temp)"
+    r"(?:/[A-Za-z0-9._+/@~-]+)?|<(?:external|relative)-path>"
+)
+ALLOWED_DETAIL = re.compile(
+    rf"^\| (?:compiler (?:fatal )?error at (?:{SAFE_LOCATION_OUTPUT}):"
+    r"[0-9]+(?::[0-9]+)?: [ -~]+|"
+    rf"cmake error at (?:{SAFE_LOCATION_OUTPUT}):[0-9]+|"
+    r"compiler driver error: [ -~]+|"
+    r"linker error: (?:command failed|undefined symbols for architecture [A-Za-z0-9_-]{1,32})|"
+    r"build tool error: command failed|autogen error: subprocess failed)$"
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -34,7 +85,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--build-root")
     parser.add_argument("--prefix-root")
     parser.add_argument("--temp-root")
-    parser.add_argument("--max-lines", type=int, default=120)
+    parser.add_argument("--max-lines", type=int, default=80)
+    parser.add_argument("--max-line-bytes", type=int, default=768)
+    parser.add_argument("--max-output-bytes", type=int, default=49152)
+    parser.add_argument("--max-input-bytes", type=int, default=8 * 1024 * 1024)
     return parser.parse_args()
 
 
@@ -49,53 +103,244 @@ def root_replacements(args: argparse.Namespace):
     for raw_path, label in candidates:
         if not raw_path:
             continue
-        path = str(Path(raw_path).expanduser()).rstrip("/")
+        path = str(Path(raw_path).expanduser()).rstrip("/\\")
         if path:
             replacements.append((path, label))
     return sorted(replacements, key=lambda item: len(item[0]), reverse=True)
 
 
-def sanitize(line: str, replacements) -> str:
-    line = ANSI_ESCAPE.sub("", line)
-    line = CONTROL_CHARACTER.sub("", line)
-    for path, label in replacements:
-        line = line.replace(path, label)
-    line = HOME_PATH.sub("<home-path>", line)
-    line = TEMP_PATH.sub("<temp-path>", line)
-    line = PRIVATE_IPV4.sub("<private-address>", line)
-    line = PRIVATE_IPV6.sub("<private-address>", line)
-    line = SENSITIVE_ASSIGNMENT.sub(lambda match: f"{match.group(1)}=<redacted>", line)
-    line = KNOWN_TOKEN.sub("<redacted-token>", line)
-    line = URL_USERINFO.sub(r"\1<redacted>@", line)
-    if KEY_MATERIAL.search(line):
-        line = "<redacted-key-material>"
-    return line.rstrip()
+def read_bounded_tail(path: Path, max_bytes: int):
+    size = path.stat().st_size
+    offset = max(0, size - max_bytes)
+    with path.open("rb") as handle:
+        handle.seek(offset)
+        raw = handle.read(max_bytes)
+    if offset:
+        newline = raw.find(b"\n")
+        raw = b"" if newline < 0 else raw[newline + 1 :]
+    return raw.decode("utf-8", errors="replace").splitlines(), bool(offset)
+
+
+def strip_controls(value: str) -> str:
+    value = ANSI_ESCAPE.sub("", value)
+    value = CONTROL_CHARACTER.sub("", value)
+    return "".join(character if ord(character) < 128 else "?" for character in value)
+
+
+def safe_path_fragment(value: str) -> str:
+    value = value.replace("\\", "/").lstrip("/")
+    pieces = []
+    for piece in value.split("/"):
+        if not piece or piece in (".", ".."):
+            continue
+        if len(piece) > 64 or SENSITIVE_TERM.search(piece) or OPAQUE_VALUE.search(piece):
+            pieces.append("_redacted_")
+            continue
+        safe_piece = re.sub(r"[^A-Za-z0-9._+@~-]", "_", piece)
+        pieces.append(safe_piece or "_")
+    result = "/".join(pieces)[:240]
+    return result or "_"
+
+
+def normalize_location(raw_path: str, replacements) -> str:
+    path = strip_controls(raw_path.strip())
+    normalized = path.replace("\\", "/")
+    for root, label in replacements:
+        normalized_root = root.replace("\\", "/")
+        if normalized == normalized_root:
+            return label
+        prefix = normalized_root + "/"
+        if normalized.startswith(prefix):
+            return f"{label}/{safe_path_fragment(normalized[len(prefix):])}"
+
+    if normalized.startswith("/") or WINDOWS_PATH.search(path) or normalized.startswith("//"):
+        return "<external-path>"
+    if SAFE_RELATIVE_PATH.fullmatch(normalized):
+        return f"barrier-source/{safe_path_fragment(normalized)}"
+    return "<relative-path>"
+
+
+def sanitize_message(raw_message: str, replacements) -> str:
+    message = strip_controls(raw_message.strip())
+    if not message:
+        return "<message-unavailable>"
+    if PEM_BEGIN.search(message) or PEM_END.search(message) or SENSITIVE_TERM.search(message):
+        return "<redacted-sensitive-message>"
+
+    for root, label in replacements:
+        message = message.replace(root, label)
+    message = URL.sub("<url>", message)
+    message = UNC_PATH.sub("<external-path>", message)
+    message = WINDOWS_PATH.sub("<external-path>", message)
+    message = TILDE_PATH.sub("<external-path>", message)
+    message = POSIX_ABSOLUTE_PATH.sub("<external-path>", message)
+    message = IPV4_ADDRESS.sub("<network-address>", message)
+    message = IPV6_ADDRESS.sub("<network-address>", message)
+    message = MAC_ADDRESS.sub("<network-address>", message)
+    message = OPAQUE_VALUE.sub("<redacted-value>", message)
+    message = re.sub(r"\s+", " ", message).strip()
+    return message or "<message-unavailable>"
+
+
+def structured_diagnostic(line: str, replacements):
+    match = COMPILER_DIAGNOSTIC.match(line)
+    if match:
+        location = normalize_location(match.group("path"), replacements)
+        line_number = match.group("line")
+        column = match.group("column")
+        if column:
+            line_number = f"{line_number}:{column}"
+        severity = match.group("severity").lower()
+        message = sanitize_message(match.group("message"), replacements)
+        return f"compiler {severity} at {location}:{line_number}: {message}"
+
+    match = CMAKE_DIAGNOSTIC.match(line)
+    if match:
+        location = normalize_location(match.group("path"), replacements)
+        return f"cmake error at {location}:{match.group('line')}"
+
+    match = COMPILER_DRIVER_DIAGNOSTIC.match(line)
+    if match:
+        message = sanitize_message(match.group("message"), replacements)
+        return f"compiler driver error: {message}"
+
+    match = UNDEFINED_SYMBOLS.match(line)
+    if match and SAFE_ARCH.fullmatch(match.group("arch")):
+        return f"linker error: undefined symbols for architecture {match.group('arch')}"
+
+    if LINKER_NOT_FOUND.match(line):
+        return "linker error: command failed"
+    if BUILD_TOOL_FAILURE.match(line):
+        return "build tool error: command failed"
+    if AUTOGEN_FAILURE.match(line):
+        return "autogen error: subprocess failed"
+    return None
+
+
+def bound_line(line: str, max_bytes: int) -> str:
+    encoded = line.encode("ascii", errors="replace")
+    if len(encoded) <= max_bytes:
+        return encoded.decode("ascii")
+    suffix = b"...<truncated>"
+    return (encoded[: max_bytes - len(suffix)] + suffix).decode("ascii")
+
+
+def select_first_and_last(values, limit: int):
+    if len(values) <= limit:
+        return list(values)
+    first_count = (limit + 1) // 2
+    return list(values[:first_count]) + list(values[-(limit - first_count) :])
+
+
+def candidate_is_safe(candidate: str, max_line_bytes: int, max_output_bytes: int) -> bool:
+    encoded = candidate.encode("ascii", errors="strict")
+    if len(encoded) > max_output_bytes or CONTROL_CHARACTER.search(candidate):
+        return False
+    lines = candidate.splitlines()
+    if len(lines) < 6 or lines[0] != (
+        "release-build-diagnostics: privacy-safe structured diagnostics"
+    ):
+        return False
+    header_patterns = (
+        re.compile(r"^scanned_lines=[0-9]+$"),
+        re.compile(r"^matched_diagnostics=[0-9]+$"),
+        re.compile(r"^emitted_diagnostics=[0-9]+$"),
+        re.compile(r"^input_truncated=(?:yes|no)$"),
+    )
+    if not all(pattern.fullmatch(line) for pattern, line in zip(header_patterns, lines[1:5])):
+        return False
+    emitted_count = int(lines[3].split("=", 1)[1])
+    matched_count = int(lines[2].split("=", 1)[1])
+    if emitted_count != len(lines[5:]) or matched_count < emitted_count:
+        return False
+    for line in lines:
+        if len(line.encode("ascii")) > max_line_bytes:
+            return False
+    if not all(ALLOWED_DETAIL.fullmatch(line) for line in lines[5:]):
+        return False
+    forbidden = (
+        PEM_BEGIN,
+        PEM_END,
+        URL,
+        WINDOWS_PATH,
+        UNC_PATH,
+        TILDE_PATH,
+        POSIX_ABSOLUTE_PATH,
+        IPV4_ADDRESS,
+        IPV6_ADDRESS,
+        MAC_ADDRESS,
+        SENSITIVE_TERM,
+        OPAQUE_VALUE,
+    )
+    return not any(pattern.search(candidate) for pattern in forbidden)
 
 
 def main() -> int:
     args = parse_args()
-    if args.max_lines < 1 or args.max_lines > 500:
-        print("release-build-diagnostics: invalid line bound", file=sys.stderr)
+    if (
+        args.max_lines < 1
+        or args.max_lines > 200
+        or args.max_line_bytes < 128
+        or args.max_line_bytes > 2048
+        or args.max_output_bytes < 1024
+        or args.max_output_bytes > 131072
+        or args.max_input_bytes < 4096
+        or args.max_input_bytes > 64 * 1024 * 1024
+    ):
+        print("release-build-diagnostics: invalid bound", file=sys.stderr)
         return 2
 
     try:
-        raw_lines = Path(args.log_path).read_text(errors="replace").splitlines()
+        raw_lines, input_truncated = read_bounded_tail(
+            Path(args.log_path), args.max_input_bytes
+        )
     except OSError:
         print("release-build-diagnostics: log unavailable", file=sys.stderr)
         return 2
 
     replacements = root_replacements(args)
-    sanitized = [sanitize(line, replacements) for line in raw_lines]
-    sanitized = [line for line in sanitized if line]
-    emitted = sanitized[-args.max_lines :]
-    error_markers = sum(1 for line in sanitized if ERROR_MARKER.search(line))
+    diagnostics = []
+    inside_pem = False
+    for raw_line in raw_lines:
+        line = strip_controls(raw_line).strip()
+        if PEM_BEGIN.search(line):
+            inside_pem = True
+            continue
+        if inside_pem:
+            if PEM_END.search(line):
+                inside_pem = False
+            continue
+        diagnostic = structured_diagnostic(line, replacements)
+        if diagnostic:
+            diagnostics.append(diagnostic)
 
-    print("release-build-diagnostics: sanitized tail")
-    print(f"total_lines={len(raw_lines)}")
-    print(f"emitted_lines={len(emitted)}")
-    print(f"error_markers={error_markers}")
-    for line in emitted:
-        print(f"| {line}")
+    if not diagnostics:
+        print("release-build-diagnostics: no structured diagnostics", file=sys.stderr)
+        return 3
+
+    selected = select_first_and_last(diagnostics, args.max_lines)
+    details = [bound_line(f"| {line}", args.max_line_bytes) for line in selected]
+    while True:
+        header = [
+            "release-build-diagnostics: privacy-safe structured diagnostics",
+            f"scanned_lines={len(raw_lines)}",
+            f"matched_diagnostics={len(diagnostics)}",
+            f"emitted_diagnostics={len(details)}",
+            f"input_truncated={'yes' if input_truncated else 'no'}",
+        ]
+        candidate = "\n".join(header + details) + "\n"
+        if len(candidate.encode("ascii")) <= args.max_output_bytes:
+            break
+        if len(details) <= 1:
+            print("release-build-diagnostics: output bound unavailable", file=sys.stderr)
+            return 3
+        details.pop(len(details) // 2)
+
+    if not candidate_is_safe(candidate, args.max_line_bytes, args.max_output_bytes):
+        print("release-build-diagnostics: candidate rejected", file=sys.stderr)
+        return 3
+
+    sys.stdout.write(candidate)
     return 0
 
 

--- a/scripts/tests/sanitize-release-build-log_test.sh
+++ b/scripts/tests/sanitize-release-build-log_test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
 sanitizer="$repo_root/scripts/sanitize-release-build-log.py"
+metadata_scanner="$repo_root/scripts/scan-protected-metadata.pl"
+release_workflow="$repo_root/.github/workflows/release-macos-arm64.yml"
 test_root=$(/usr/bin/mktemp -d \
     "${TMPDIR:-/tmp}/barrier-release-log-test.XXXXXX")
 
@@ -11,27 +13,56 @@ cleanup() {
     /bin/rm -rf "$test_root"
 }
 trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
 
 source_root=/opt/barrier-diagnostic/source-root
 build_root=/opt/barrier-diagnostic/build-root
 prefix_root=/opt/barrier-diagnostic/prefix-root
 runner_temp=/opt/barrier-diagnostic/runner-temp
-private_home="/""Users""/diagnostic-user/private-source"
-private_address="192.168"".44.18"
-synthetic_token="synthetic""-token-value"
+root_path="/""root""/build-cache/private.cpp"
+var_temp_path="/""var""/tmp/build-cache/private.cpp"
+unknown_path="/""opt""/unlisted/build/private.cpp"
+windows_separator=$'\\'
+windows_path="C:${windows_separator}Users${windows_separator}runner${windows_separator}build${windows_separator}private.cpp"
+private_ipv4="192.168"".44.18"
+link_local_ipv4="169.254"".23.7"
+private_ipv6="fd12""::44"
+link_local_ipv6="fe80""::beef"
+synthetic_url="https""://example.invalid/build?trace=1"
+credential_name="GH_""TOKEN"
+authorization_name="Authori""zation"
+synthetic_value="synthetic""-credential-value"
+pem_begin="-----BE""GIN PRIVATE KEY-----"
+pem_body="c3ludGhldGljLWtleS1ib2R5LXZhbHVl"
+pem_end="-----E""ND PRIVATE KEY-----"
+opaque_value="abcdefghijklmnopqrstuvwxyz""ABCDEFGH1234567890"
 log_path="$test_root/build.log"
 output_path="$test_root/output.log"
 
-printf '%s\n' \
-    "$source_root/src/example.cpp:42:7: error: expected expression" \
-    "$build_root/generated.cpp:8:2: fatal error: header missing" \
-    "$prefix_root/lib/example.dylib: undefined symbol" \
-    "$runner_temp/intermediate.o: failed" \
-    "$private_home/file.cpp:4:1: error: private path" \
-    "connection to $private_address failed" \
-    "token=$synthetic_token" \
-    $'\033[31mclang: error: colored failure\033[0m' \
-    > "$log_path"
+{
+    printf '%s\n' \
+        "$source_root/src/example.cpp:42:7: error: expected expression" \
+        "$build_root/generated.cpp:8:2: fatal error: header missing" \
+        "CMake Error at $source_root/CMakeLists.txt:81 (message):" \
+        'Undefined symbols for architecture arm64:' \
+        "$source_root/src/credential.cpp:50:2: error: $credential_name=$synthetic_value" \
+        "$source_root/src/auth.cpp:51:2: error: $authorization_name: Bearer $synthetic_value" \
+        "$source_root/src/path.cpp:52:2: error: from $root_path $var_temp_path $unknown_path $windows_path" \
+        "$source_root/src/network.cpp:53:2: error: contacted $private_ipv4 $link_local_ipv4 $private_ipv6 $link_local_ipv6 $synthetic_url" \
+        "$source_root/src/opaque.cpp:54:2: error: value $opaque_value" \
+        "$pem_begin" \
+        "$source_root/src/key.cpp:55:2: error: $pem_body" \
+        "$pem_end" \
+        "$credential_name=$synthetic_value" \
+        "$authorization_name: Bearer $synthetic_value" \
+        $'\033[31mclang: error: colored failure\033[0m'
+    for sequence in $(/usr/bin/seq 1 121); do
+        printf 'ordinary build tail line %s\n' "$sequence"
+    done
+    printf '%s' "$source_root/src/oversized.cpp:88:2: error: "
+    /usr/bin/perl -e 'print "word " x 40000'
+    printf '\n'
+} > "$log_path"
 
 /usr/bin/python3 "$sanitizer" "$log_path" \
     --source-root "$source_root" \
@@ -40,17 +71,32 @@ printf '%s\n' \
     --temp-root "$runner_temp" \
     --max-lines 20 > "$output_path"
 
-/usr/bin/grep -F 'barrier-source/src/example.cpp:42:7: error:' "$output_path" >/dev/null
-/usr/bin/grep -F 'barrier-build/generated.cpp:8:2: fatal error:' "$output_path" >/dev/null
-/usr/bin/grep -F 'barrier-prefix/lib/example.dylib: undefined symbol' "$output_path" >/dev/null
-/usr/bin/grep -F 'runner-temp/intermediate.o: failed' "$output_path" >/dev/null
-/usr/bin/grep -F 'token=<redacted>' "$output_path" >/dev/null
-/usr/bin/grep -F 'clang: error: colored failure' "$output_path" >/dev/null
+/usr/bin/grep -F \
+    '| compiler error at barrier-source/src/example.cpp:42:7: expected expression' \
+    "$output_path" >/dev/null
+/usr/bin/grep -F \
+    '| compiler fatal error at barrier-build/generated.cpp:8:2: header missing' \
+    "$output_path" >/dev/null
+/usr/bin/grep -F \
+    '| cmake error at barrier-source/CMakeLists.txt:81' \
+    "$output_path" >/dev/null
+/usr/bin/grep -F \
+    '| linker error: undefined symbols for architecture arm64' \
+    "$output_path" >/dev/null
+/usr/bin/grep -F '<redacted-sensitive-message>' "$output_path" >/dev/null
+/usr/bin/grep -F '<external-path>' "$output_path" >/dev/null
+/usr/bin/grep -F '<network-address>' "$output_path" >/dev/null
+/usr/bin/grep -F '<url>' "$output_path" >/dev/null
+/usr/bin/grep -F '<redacted-value>' "$output_path" >/dev/null
+/usr/bin/grep -F 'compiler driver error: colored failure' "$output_path" >/dev/null
+/usr/bin/grep -F '<truncated>' "$output_path" >/dev/null
 
 for protected_value in \
-    "$source_root" "$build_root" "$prefix_root" "$runner_temp" \
-    "$private_home" "$private_address" "$synthetic_token"; do
-    if /usr/bin/grep -F "$protected_value" "$output_path" >/dev/null; then
+    "$root_path" "$var_temp_path" "$unknown_path" "$windows_path" \
+    "$private_ipv4" "$link_local_ipv4" "$private_ipv6" "$link_local_ipv6" \
+    "$synthetic_url" "$credential_name" "$authorization_name" \
+    "$synthetic_value" "$pem_begin" "$pem_body" "$pem_end" "$opaque_value"; do
+    if /usr/bin/grep -F -- "$protected_value" "$output_path" >/dev/null; then
         echo 'sanitized build diagnostic exposed protected input' >&2
         exit 1
     fi
@@ -60,20 +106,67 @@ if LC_ALL=C /usr/bin/grep $'\033' "$output_path" >/dev/null; then
     echo 'sanitized build diagnostic retained terminal control characters' >&2
     exit 1
 fi
+if /usr/bin/awk 'length($0) > 768 { exit 1 }' "$output_path"; then
+    :
+else
+    echo 'sanitized build diagnostic exceeded its per-line bound' >&2
+    exit 1
+fi
+if [ "$(/usr/bin/wc -c < "$output_path")" -gt 49152 ]; then
+    echo 'sanitized build diagnostic exceeded its total byte bound' >&2
+    exit 1
+fi
+/usr/bin/perl "$metadata_scanner" --source-path "$output_path" >/dev/null
 
-/usr/bin/perl "$repo_root/scripts/scan-protected-metadata.pl" \
-    --source-path "$output_path" >/dev/null
+unstructured_log="$test_root/unstructured.log"
+unstructured_output="$test_root/unstructured.stdout"
+printf '%s\n' \
+    "$credential_name=$synthetic_value" \
+    "$pem_begin" "$pem_body" "$pem_end" \
+    > "$unstructured_log"
+if /usr/bin/python3 "$sanitizer" "$unstructured_log" \
+    > "$unstructured_output" 2> "$test_root/unstructured.stderr"; then
+    echo 'sanitizer accepted an unstructured hostile log' >&2
+    exit 1
+fi
+if [ -s "$unstructured_output" ]; then
+    echo 'sanitizer emitted an unvalidated partial candidate' >&2
+    exit 1
+fi
+/usr/bin/grep -F 'no structured diagnostics' \
+    "$test_root/unstructured.stderr" >/dev/null
 
-missing_path="$private_home/missing-build.log"
+missing_path="$root_path/missing-build.log"
 if /usr/bin/python3 "$sanitizer" "$missing_path" \
-    >"$test_root/missing.stdout" 2>"$test_root/missing.stderr"; then
+    > "$test_root/missing.stdout" 2> "$test_root/missing.stderr"; then
     echo 'sanitizer accepted a missing log' >&2
     exit 1
 fi
-if /usr/bin/grep -F "$missing_path" "$test_root/missing.stderr" >/dev/null; then
+if [ -s "$test_root/missing.stdout" ] \
+    || /usr/bin/grep -F "$missing_path" "$test_root/missing.stderr" >/dev/null; then
     echo 'missing-log diagnostic exposed its input path' >&2
     exit 1
 fi
 /usr/bin/grep -F 'log unavailable' "$test_root/missing.stderr" >/dev/null
+
+# These are intentionally literal workflow source fragments.
+# shellcheck disable=SC2016
+capture_line=$(/usr/bin/grep -nF '>"$diagnostic_output" 2>/dev/null' \
+    "$release_workflow" | /usr/bin/cut -d: -f1)
+scan_line=$(/usr/bin/grep -nF '&& /usr/bin/perl scripts/scan-protected-metadata.pl' \
+    "$release_workflow" | /usr/bin/cut -d: -f1)
+# shellcheck disable=SC2016
+emit_line=$(/usr/bin/grep -nF '/bin/cat "$diagnostic_output"' \
+    "$release_workflow" | /usr/bin/cut -d: -f1)
+case "$capture_line:$scan_line:$emit_line" in
+    *[!0-9:]*|:*|*::*|*:) workflow_order_is_valid=0 ;;
+    *) workflow_order_is_valid=1 ;;
+esac
+if [ "$workflow_order_is_valid" -ne 1 ] \
+    || [ "$capture_line" -ge "$scan_line" ] \
+    || [ "$scan_line" -ge "$emit_line" ]; then
+    echo 'release workflow does not validate captured diagnostics before emission' >&2
+    exit 1
+fi
 
 printf 'release build log sanitizer tests passed\n'

--- a/scripts/tests/sanitize-release-build-log_test.sh
+++ b/scripts/tests/sanitize-release-build-log_test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
 sanitizer="$repo_root/scripts/sanitize-release-build-log.py"
+emitter="$repo_root/scripts/emit-sanitized-release-diagnostics.sh"
 metadata_scanner="$repo_root/scripts/scan-protected-metadata.pl"
 release_workflow="$repo_root/.github/workflows/release-macos-arm64.yml"
 test_root=$(/usr/bin/mktemp -d \
@@ -116,7 +117,47 @@ if [ "$(/usr/bin/wc -c < "$output_path")" -gt 49152 ]; then
     echo 'sanitized build diagnostic exceeded its total byte bound' >&2
     exit 1
 fi
-/usr/bin/perl "$metadata_scanner" --source-path "$output_path" >/dev/null
+/usr/bin/perl "$metadata_scanner" --source "$output_path" >/dev/null
+
+hosted_runner_temp="$test_root/""Users""/runner/work/_temp"
+/bin/mkdir -p "$hosted_runner_temp"
+emitted_output="$test_root/emitted.log"
+"$emitter" \
+    "$log_path" \
+    "$source_root" \
+    "$build_root" \
+    "$prefix_root" \
+    "$hosted_runner_temp" > "$emitted_output"
+/usr/bin/grep -F \
+    '| compiler error at barrier-source/src/example.cpp:42:7: expected expression' \
+    "$emitted_output" >/dev/null
+/usr/bin/perl "$metadata_scanner" --source "$emitted_output" >/dev/null
+
+emitter_sandbox="$test_root/emitter-sandbox"
+/bin/mkdir -p "$emitter_sandbox"
+/bin/cp "$emitter" "$emitter_sandbox/emit-sanitized-release-diagnostics.sh"
+/bin/cp "$metadata_scanner" "$emitter_sandbox/scan-protected-metadata.pl"
+printf '%s\n' \
+    '#!/usr/bin/env python3' \
+    'import os' \
+    'print(os.environ["SYNTHETIC_DIAGNOSTIC"])' \
+    > "$emitter_sandbox/sanitize-release-build-log.py"
+hostile_candidate="compiler error at barrier-source/src/example.cpp:1:1: $root_path"
+hostile_emission="$test_root/hostile-emission.log"
+if SYNTHETIC_DIAGNOSTIC="$hostile_candidate" \
+    "$emitter_sandbox/emit-sanitized-release-diagnostics.sh" \
+        "$log_path" \
+        "$source_root" \
+        "$build_root" \
+        "$prefix_root" \
+        "$hosted_runner_temp" > "$hostile_emission"; then
+    echo 'diagnostic emitter accepted hostile generated content' >&2
+    exit 1
+fi
+if [ -s "$hostile_emission" ]; then
+    echo 'diagnostic emitter exposed hostile generated content' >&2
+    exit 1
+fi
 
 unstructured_log="$test_root/unstructured.log"
 unstructured_output="$test_root/unstructured.stdout"
@@ -149,24 +190,10 @@ if [ -s "$test_root/missing.stdout" ] \
 fi
 /usr/bin/grep -F 'log unavailable' "$test_root/missing.stderr" >/dev/null
 
-# These are intentionally literal workflow source fragments.
+/usr/bin/grep -F 'scripts/emit-sanitized-release-diagnostics.sh' \
+    "$release_workflow" >/dev/null
+# This is intentionally a literal helper source fragment.
 # shellcheck disable=SC2016
-capture_line=$(/usr/bin/grep -nF '>"$diagnostic_output" 2>/dev/null' \
-    "$release_workflow" | /usr/bin/cut -d: -f1)
-scan_line=$(/usr/bin/grep -nF '&& /usr/bin/perl scripts/scan-protected-metadata.pl' \
-    "$release_workflow" | /usr/bin/cut -d: -f1)
-# shellcheck disable=SC2016
-emit_line=$(/usr/bin/grep -nF '/bin/cat "$diagnostic_output"' \
-    "$release_workflow" | /usr/bin/cut -d: -f1)
-case "$capture_line:$scan_line:$emit_line" in
-    *[!0-9:]*|:*|*::*|*:) workflow_order_is_valid=0 ;;
-    *) workflow_order_is_valid=1 ;;
-esac
-if [ "$workflow_order_is_valid" -ne 1 ] \
-    || [ "$capture_line" -ge "$scan_line" ] \
-    || [ "$scan_line" -ge "$emit_line" ]; then
-    echo 'release workflow does not validate captured diagnostics before emission' >&2
-    exit 1
-fi
+/usr/bin/grep -F -- '--source "$diagnostic_output"' "$emitter" >/dev/null
 
 printf 'release build log sanitizer tests passed\n'

--- a/scripts/tests/sanitize-release-build-log_test.sh
+++ b/scripts/tests/sanitize-release-build-log_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
+sanitizer="$repo_root/scripts/sanitize-release-build-log.py"
+test_root=$(/usr/bin/mktemp -d \
+    "${TMPDIR:-/tmp}/barrier-release-log-test.XXXXXX")
+
+cleanup() {
+    /bin/rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+source_root=/opt/barrier-diagnostic/source-root
+build_root=/opt/barrier-diagnostic/build-root
+prefix_root=/opt/barrier-diagnostic/prefix-root
+runner_temp=/opt/barrier-diagnostic/runner-temp
+private_home="/""Users""/diagnostic-user/private-source"
+private_address="192.168"".44.18"
+synthetic_token="synthetic""-token-value"
+log_path="$test_root/build.log"
+output_path="$test_root/output.log"
+
+printf '%s\n' \
+    "$source_root/src/example.cpp:42:7: error: expected expression" \
+    "$build_root/generated.cpp:8:2: fatal error: header missing" \
+    "$prefix_root/lib/example.dylib: undefined symbol" \
+    "$runner_temp/intermediate.o: failed" \
+    "$private_home/file.cpp:4:1: error: private path" \
+    "connection to $private_address failed" \
+    "token=$synthetic_token" \
+    $'\033[31mclang: error: colored failure\033[0m' \
+    > "$log_path"
+
+/usr/bin/python3 "$sanitizer" "$log_path" \
+    --source-root "$source_root" \
+    --build-root "$build_root" \
+    --prefix-root "$prefix_root" \
+    --temp-root "$runner_temp" \
+    --max-lines 20 > "$output_path"
+
+/usr/bin/grep -F 'barrier-source/src/example.cpp:42:7: error:' "$output_path" >/dev/null
+/usr/bin/grep -F 'barrier-build/generated.cpp:8:2: fatal error:' "$output_path" >/dev/null
+/usr/bin/grep -F 'barrier-prefix/lib/example.dylib: undefined symbol' "$output_path" >/dev/null
+/usr/bin/grep -F 'runner-temp/intermediate.o: failed' "$output_path" >/dev/null
+/usr/bin/grep -F 'token=<redacted>' "$output_path" >/dev/null
+/usr/bin/grep -F 'clang: error: colored failure' "$output_path" >/dev/null
+
+for protected_value in \
+    "$source_root" "$build_root" "$prefix_root" "$runner_temp" \
+    "$private_home" "$private_address" "$synthetic_token"; do
+    if /usr/bin/grep -F "$protected_value" "$output_path" >/dev/null; then
+        echo 'sanitized build diagnostic exposed protected input' >&2
+        exit 1
+    fi
+done
+
+if LC_ALL=C /usr/bin/grep $'\033' "$output_path" >/dev/null; then
+    echo 'sanitized build diagnostic retained terminal control characters' >&2
+    exit 1
+fi
+
+/usr/bin/perl "$repo_root/scripts/scan-protected-metadata.pl" \
+    --source-path "$output_path" >/dev/null
+
+missing_path="$private_home/missing-build.log"
+if /usr/bin/python3 "$sanitizer" "$missing_path" \
+    >"$test_root/missing.stdout" 2>"$test_root/missing.stderr"; then
+    echo 'sanitizer accepted a missing log' >&2
+    exit 1
+fi
+if /usr/bin/grep -F "$missing_path" "$test_root/missing.stderr" >/dev/null; then
+    echo 'missing-log diagnostic exposed its input path' >&2
+    exit 1
+fi
+/usr/bin/grep -F 'log unavailable' "$test_root/missing.stderr" >/dev/null
+
+printf 'release build log sanitizer tests passed\n'

--- a/scripts/tests/sanitize-release-build-log_test.sh
+++ b/scripts/tests/sanitize-release-build-log_test.sh
@@ -32,7 +32,10 @@ link_local_ipv6="fe80""::beef"
 synthetic_url="https""://example.invalid/build?trace=1"
 credential_name="GH_""TOKEN"
 authorization_name="Authori""zation"
+api_key_name="API_""KEY"
 synthetic_value="synthetic""-credential-value"
+short_synthetic_value="short""-value"
+spaced_home_path="/""Users""/synthetic user/private source.cpp"
 pem_begin="-----BE""GIN PRIVATE KEY-----"
 pem_body="c3ludGhldGljLWtleS1ib2R5LXZhbHVl"
 pem_end="-----E""ND PRIVATE KEY-----"
@@ -48,6 +51,9 @@ output_path="$test_root/output.log"
         'Undefined symbols for architecture arm64:' \
         "$source_root/src/credential.cpp:50:2: error: $credential_name=$synthetic_value" \
         "$source_root/src/auth.cpp:51:2: error: $authorization_name: Bearer $synthetic_value" \
+        "$source_root/src/api.cpp:51:3: error: $api_key_name=$short_synthetic_value" \
+        "$source_root/src/spaced.cpp:51:4: error: from $spaced_home_path" \
+        "$spaced_home_path:51:5: error: spaced location" \
         "$source_root/src/path.cpp:52:2: error: from $root_path $var_temp_path $unknown_path $windows_path" \
         "$source_root/src/network.cpp:53:2: error: contacted $private_ipv4 $link_local_ipv4 $private_ipv6 $link_local_ipv6 $synthetic_url" \
         "$source_root/src/opaque.cpp:54:2: error: value $opaque_value" \
@@ -73,10 +79,10 @@ output_path="$test_root/output.log"
     --max-lines 20 > "$output_path"
 
 /usr/bin/grep -F \
-    '| compiler error at barrier-source/src/example.cpp:42:7: expected expression' \
+    '| compiler error at barrier-source/src/example.cpp:42:7' \
     "$output_path" >/dev/null
 /usr/bin/grep -F \
-    '| compiler fatal error at barrier-build/generated.cpp:8:2: header missing' \
+    '| compiler fatal error at barrier-build/generated.cpp:8:2' \
     "$output_path" >/dev/null
 /usr/bin/grep -F \
     '| cmake error at barrier-source/CMakeLists.txt:81' \
@@ -84,19 +90,19 @@ output_path="$test_root/output.log"
 /usr/bin/grep -F \
     '| linker error: undefined symbols for architecture arm64' \
     "$output_path" >/dev/null
-/usr/bin/grep -F '<redacted-sensitive-message>' "$output_path" >/dev/null
 /usr/bin/grep -F '<external-path>' "$output_path" >/dev/null
-/usr/bin/grep -F '<network-address>' "$output_path" >/dev/null
-/usr/bin/grep -F '<url>' "$output_path" >/dev/null
-/usr/bin/grep -F '<redacted-value>' "$output_path" >/dev/null
-/usr/bin/grep -F 'compiler driver error: colored failure' "$output_path" >/dev/null
-/usr/bin/grep -F '<truncated>' "$output_path" >/dev/null
+/usr/bin/grep -F 'compiler driver error: command failed' "$output_path" >/dev/null
+/usr/bin/grep -F \
+    '| compiler error at barrier-source/src/oversized.cpp:88:2' \
+    "$output_path" >/dev/null
 
 for protected_value in \
     "$root_path" "$var_temp_path" "$unknown_path" "$windows_path" \
     "$private_ipv4" "$link_local_ipv4" "$private_ipv6" "$link_local_ipv6" \
     "$synthetic_url" "$credential_name" "$authorization_name" \
-    "$synthetic_value" "$pem_begin" "$pem_body" "$pem_end" "$opaque_value"; do
+    "$api_key_name" "$synthetic_value" "$short_synthetic_value" \
+    "$spaced_home_path" "$pem_begin" "$pem_body" "$pem_end" "$opaque_value" \
+    'expected expression' 'header missing' 'colored failure'; do
     if /usr/bin/grep -F -- "$protected_value" "$output_path" >/dev/null; then
         echo 'sanitized build diagnostic exposed protected input' >&2
         exit 1
@@ -129,7 +135,7 @@ emitted_output="$test_root/emitted.log"
     "$prefix_root" \
     "$hosted_runner_temp" > "$emitted_output"
 /usr/bin/grep -F \
-    '| compiler error at barrier-source/src/example.cpp:42:7: expected expression' \
+    '| compiler error at barrier-source/src/example.cpp:42:7' \
     "$emitted_output" >/dev/null
 /usr/bin/perl "$metadata_scanner" --source "$emitted_output" >/dev/null
 


### PR DESCRIPTION
Closes #47

## Summary
- extract only structured compiler, CMake, linker, and build-tool failures
- normalize locations and redact credentials, key material, network addresses, URLs, and unknown paths
- validate the complete byte-bounded candidate before output, then run a second protected-metadata scan before workflow emission
- cover hostile inputs, noisy tails, oversized lines, missing logs, and workflow capture ordering

## Verification
- `scripts/tests/sanitize-release-build-log_test.sh`
- `scripts/tests/scan-protected-metadata_test.sh`
- `scripts/tests/build-macos-release-prefix_diagnostics_test.sh`
- `scripts/tests/verify-macos-deployment-target_test.sh`
- `scripts/tests/public-audit_test.sh`
- `scripts/public-audit.sh`
- actionlint, shellcheck, Python syntax, and `git diff --check`