### PR TITLE
Build releases from immutable protected tags

### DIFF
--- a/.github/workflows/ci-local.yml
+++ b/.github/workflows/ci-local.yml
@@ -41,6 +41,7 @@ jobs:
           scripts/tests/scan-protected-metadata_test.sh
           scripts/tests/build-macos-release-prefix_diagnostics_test.sh
           scripts/tests/sanitize-release-build-log_test.sh
+          scripts/tests/verify-release-checks_test.sh
           scripts/tests/verify-macos-deployment-target_test.sh
           scripts/tests/public-audit_test.sh
 

--- a/.github/workflows/ci-local.yml
+++ b/.github/workflows/ci-local.yml
@@ -41,7 +41,10 @@ jobs:
           scripts/tests/scan-protected-metadata_test.sh
           scripts/tests/build-macos-release-prefix_diagnostics_test.sh
           scripts/tests/sanitize-release-build-log_test.sh
+          scripts/tests/parse-release-provenance_test.sh
           scripts/tests/verify-release-checks_test.sh
+          scripts/tests/verify-release-recipe-pair_test.sh
+          scripts/tests/verify-release-tag_test.sh
           scripts/tests/verify-macos-deployment-target_test.sh
           scripts/tests/public-audit_test.sh
 

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -2,13 +2,18 @@ name: release-macos-arm64
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Annotated vMAJOR.MINOR.PATCH release tag
+        required: true
+        type: string
 
 permissions:
   actions: read
   contents: read
 
 concurrency:
-  group: release-macos-arm64-${{ github.ref }}
+  group: release-macos-arm64-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 jobs:
@@ -16,37 +21,106 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 180
     env:
+      AUTOMATION_TAG: v3.4.0-automation.1
       RELEASE_PREFIX: /tmp/barrier-release-prefix
       RELEASE_WORK_DIR: /tmp/barrier-release-work
       RELEASE_BUILD_DIR: /tmp/barrier-release-build
+    defaults:
+      run:
+        shell: bash
+        working-directory: source
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Checkout release automation
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          path: automation
           fetch-depth: 0
-          submodules: recursive
+          persist-credentials: false
 
-      - name: Verify release provenance
+      - name: Verify release automation
+        working-directory: automation
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$GITHUB_REF" = refs/heads/main
+          test "$GITHUB_REF" = "refs/tags/$AUTOMATION_TAG"
+          test "$GITHUB_REF_TYPE" = tag
+          test "$GITHUB_REF_PROTECTED" = true
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           git fetch --quiet --no-tags origin refs/heads/main:refs/remotes/origin/main
-          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
-          for required_workflow in ci.yml public-audit.yml; do
-            successful_runs=$(gh api \
-                "repos/$GITHUB_REPOSITORY/actions/workflows/$required_workflow/runs" \
-                --method GET \
-                -f head_sha="$GITHUB_SHA" \
-                -f status=completed \
-                -f per_page=100 \
-                --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')
-            if test "$successful_runs" -le 0; then
-              echo 'required release check is not successful for this commit' >&2
-              exit 1
-            fi
-          done
+          git merge-base --is-ancestor \
+            "$GITHUB_SHA" refs/remotes/origin/main
+          scripts/verify-release-checks.sh "$GITHUB_REPOSITORY" "$GITHUB_SHA"
+
+      - name: Resolve immutable release tag
+        id: release_source
+        working-directory: automation
+        env:
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          provenance_file="$RUNNER_TEMP/release-source.env"
+          /usr/bin/python3 scripts/verify-release-tag.py resolve \
+            --repo . \
+            --release-tag "$RELEASE_TAG_INPUT" \
+            --automation-tag "$AUTOMATION_TAG" \
+            --automation-sha "$GITHUB_SHA" \
+            --version-file-sha256 \
+              7b496edf4f4f626f6f9da9069b40437181a7121e3e342df4b0965c3096f63e98 \
+            >"$provenance_file"
+          canonical_env="$RUNNER_TEMP/release-source.github-env"
+          canonical_output="$RUNNER_TEMP/release-source.github-output"
+          /usr/bin/python3 scripts/parse-release-provenance.py \
+            --input "$provenance_file" \
+            --github-env "$canonical_env" \
+            --github-output "$canonical_output"
+          /bin/cat "$canonical_env" >>"$GITHUB_ENV"
+          /bin/cat "$canonical_output" >>"$GITHUB_OUTPUT"
+
+      - name: Checkout immutable release source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ steps.release_source.outputs.source_sha }}
+          path: source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate public submodule declarations
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 ../automation/scripts/verify-release-tag.py \
+            verify-source \
+            --source-dir . \
+            --source-sha "$SOURCE_SHA" \
+            --phase pre-init \
+            >"$RUNNER_TEMP/release-submodules-pre.env"
+
+      - name: Initialize exact public submodules
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 ../automation/scripts/verify-release-tag.py \
+            initialize-submodules \
+            --source-dir . \
+            --source-sha "$SOURCE_SHA" \
+            >"$RUNNER_TEMP/release-submodules-init.env"
+
+      - name: Verify tagged release source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 ../automation/scripts/verify-release-tag.py \
+            verify-source \
+            --source-dir . \
+            --source-sha "$SOURCE_SHA" \
+            --phase post-init \
+            >"$RUNNER_TEMP/release-submodules-post.env"
+          /usr/bin/python3 ../automation/scripts/verify-release-recipe-pair.py \
+            --release-tag "$RELEASE_TAG" \
+            --source-workflow .github/workflows/release-macos-arm64.yml \
+            --automation-workflow ../automation/.github/workflows/release-macos-arm64.yml
+          ../automation/scripts/verify-release-checks.sh \
+            "$GITHUB_REPOSITORY" "$GITHUB_SHA" "$SOURCE_SHA"
 
       - name: Load locked release platform
         run: |
@@ -59,25 +133,11 @@ jobs:
           printf 'MACOS_RELEASE_ARCH=%s\n' "$MACOS_RELEASE_ARCH" >> "$GITHUB_ENV"
           printf 'MACOSX_DEPLOYMENT_TARGET=%s\n' "$MACOSX_DEPLOYMENT_TARGET" >> "$GITHUB_ENV"
 
-      - name: Restore locked dependency prefix
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ env.RELEASE_PREFIX }}
-          key: >-
-            barrier-release-prefix-${{ runner.os }}-${{ runner.arch }}-${{
-            hashFiles(
-              'dist/macos/release-dependencies.lock',
-              'dist/macos/qtbase-5.15.19-xcode26.patch',
-              'scripts/build-macos-release-prefix.sh',
-              'scripts/macos-macho-closure.py',
-              'scripts/scan-protected-metadata.pl',
-              'scripts/verify-macos-deployment-target.sh'
-            )
-            }}
-
-      - name: Build or verify locked dependency prefix
+      - name: Build locked dependency prefix from source
         run: |
           set -euo pipefail
+          test ! -e "$RELEASE_PREFIX"
+          test ! -e "$RELEASE_WORK_DIR"
           build_log="$RUNNER_TEMP/release-prefix-build.log"
           if ! scripts/build-macos-release-prefix.sh \
               --prefix "$RELEASE_PREFIX" \
@@ -103,6 +163,7 @@ jobs:
           export PATH="$RELEASE_PREFIX/bin:/usr/bin:/bin:/usr/sbin:/sbin"
           export CPPFLAGS="-I$RELEASE_PREFIX/include"
           export LDFLAGS="-L$RELEASE_PREFIX/lib"
+          export GIT_COMMIT="$SOURCE_SHA"
           if ! "$cmake_bin" -S . -B "$RELEASE_BUILD_DIR" \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_OSX_ARCHITECTURES="$MACOS_RELEASE_ARCH" \
@@ -131,9 +192,9 @@ jobs:
           if ! "$cmake_bin" --build "$RELEASE_BUILD_DIR" --parallel 3 \
               >"$build_log" 2>&1; then
             echo 'locked release build failed' >&2
-            if ! scripts/emit-sanitized-release-diagnostics.sh \
+            if ! ../automation/scripts/emit-sanitized-release-diagnostics.sh \
                 "$build_log" \
-                "$GITHUB_WORKSPACE" \
+                "$GITHUB_WORKSPACE/source" \
                 "$RELEASE_BUILD_DIR" \
                 "$RELEASE_PREFIX" \
                 "$RUNNER_TEMP"; then
@@ -223,31 +284,56 @@ jobs:
               '^(VERIFIED_ARCH|MAX_MACOS_DEPLOYMENT_TARGET|MACHO_FILES_VERIFIED)=' \
               "$audit_log"
           scripts/public-audit.sh
+          expected_revision=${SOURCE_SHA:0:8}
+          /usr/bin/strings -a "$app/Contents/MacOS/barrier" \
+            | /usr/bin/grep -F "$expected_revision" >/dev/null
 
       - name: Create unsigned release input
         id: unsigned
         run: |
           set -euo pipefail
           app="$RELEASE_BUILD_DIR/bundle/Barrier.app"
-          short_sha=${GITHUB_SHA:0:8}
-          archive="$RUNNER_TEMP/Barrier-app-unsigned-$short_sha.zip"
+          short_sha=${SOURCE_SHA:0:8}
+          archive="$RUNNER_TEMP/Barrier-$RELEASE_TAG-macos-arm64-unsigned-$short_sha.zip"
           /usr/bin/ditto -c -k --keepParent "$app" "$archive"
           archive_sha=$(/usr/bin/shasum -a 256 "$archive" | /usr/bin/awk '{print $1}')
           version=$(/usr/bin/plutil -extract CFBundleShortVersionString raw \
               "$app/Contents/Info.plist")
+          test "$version" = "$RELEASE_VERSION"
           printf 'archive=%s\n' "$archive" >> "$GITHUB_OUTPUT"
           {
             printf '### Unsigned macOS arm64 release input\n\n'
             printf -- "- Version: \`%s\`\n" "$version"
-            printf -- "- Commit: \`%s\`\n" "$GITHUB_SHA"
+            printf -- "- Release tag: \`%s\`\n" "$RELEASE_TAG"
+            printf -- "- Source commit: \`%s\`\n" "$SOURCE_SHA"
+            printf -- "- Automation tag: \`%s\`\n" "$AUTOMATION_TAG"
+            printf -- "- Automation commit: \`%s\`\n" "$GITHUB_SHA"
             printf -- "- Minimum macOS: \`%s\`\n" "$MACOSX_DEPLOYMENT_TARGET"
             printf -- "- SHA-256: \`%s\`\n" "$archive_sha"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Recheck immutable release provenance
+        working-directory: automation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 scripts/verify-release-tag.py recheck \
+            --repo . \
+            --release-tag "$RELEASE_TAG" \
+            --tag-object-sha "$TAG_OBJECT_SHA" \
+            --source-sha "$SOURCE_SHA" \
+            --automation-tag "$AUTOMATION_TAG" \
+            --automation-tag-object-sha "$AUTOMATION_TAG_OBJECT_SHA" \
+            --automation-sha "$GITHUB_SHA" \
+            >"$RUNNER_TEMP/release-tag-recheck.env"
+          scripts/verify-release-checks.sh \
+            "$GITHUB_REPOSITORY" "$GITHUB_SHA" "$SOURCE_SHA"
+
       - name: Upload unsigned release input
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: Barrier-macos-arm64-unsigned-${{ github.sha }}
+          name: Barrier-${{ steps.release_source.outputs.release_tag }}-macos-arm64-unsigned-${{ steps.release_source.outputs.source_sha }}
           path: ${{ steps.unsigned.outputs.archive }}
           if-no-files-found: error
           retention-days: 14

--- a/scripts/parse-release-provenance.py
+++ b/scripts/parse-release-provenance.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+"""Parse validated release provenance into canonical GitHub command files."""
+
+import argparse
+import os
+import re
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+
+MAX_INPUT_BYTES = 8192
+REQUIRED_KEYS = (
+    "RELEASE_TAG",
+    "RELEASE_VERSION",
+    "TAG_OBJECT_SHA",
+    "SOURCE_SHA",
+    "AUTOMATION_SHA",
+    "AUTOMATION_TAG",
+    "AUTOMATION_TAG_OBJECT_SHA",
+)
+SEMVER_COMPONENT = r"(0|[1-9][0-9]*)"
+RELEASE_TAG_RE = re.compile(
+    rf"^v{SEMVER_COMPONENT}\.{SEMVER_COMPONENT}\.{SEMVER_COMPONENT}$"
+)
+RELEASE_VERSION_RE = re.compile(
+    rf"^{SEMVER_COMPONENT}\.{SEMVER_COMPONENT}\.{SEMVER_COMPONENT}$"
+)
+AUTOMATION_TAG_RE = re.compile(
+    rf"^v{SEMVER_COMPONENT}\.{SEMVER_COMPONENT}\.{SEMVER_COMPONENT}"
+    r"-automation\.([1-9][0-9]*)$"
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+TEMP_PREFIX = ".release-provenance."
+
+
+class ProvenanceError(Exception):
+    """A category-only failure safe to expose in release logs."""
+
+    def __init__(self, category: str):
+        super().__init__(category)
+        self.category = category
+
+
+class SafeArgumentParser(argparse.ArgumentParser):
+    """Do not reflect malformed path or value arguments into logs."""
+
+    def error(self, message: str) -> None:
+        del message
+        raise ProvenanceError("invalid-arguments")
+
+
+@dataclass(frozen=True)
+class OutputPlan:
+    target: Path
+    canonical_target: str
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class StagedOutput:
+    plan: OutputPlan
+    temporary: Path
+    device: int
+    inode: int
+
+
+def read_bounded_ascii_file(path_value: str) -> str:
+    path = Path(path_value)
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        raise ProvenanceError("input-unavailable")
+
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ProvenanceError("input-unavailable")
+        with os.fdopen(descriptor, "rb", closefd=True) as handle:
+            descriptor = -1
+            data = handle.read(MAX_INPUT_BYTES + 1)
+    except ProvenanceError:
+        raise
+    except OSError:
+        raise ProvenanceError("input-unavailable")
+    finally:
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+    if not data or len(data) > MAX_INPUT_BYTES:
+        raise ProvenanceError("invalid-input-size")
+    if any(byte > 0x7E or (byte < 0x20 and byte != 0x0A) for byte in data):
+        raise ProvenanceError("invalid-input-character")
+    try:
+        return data.decode("ascii")
+    except UnicodeDecodeError:
+        raise ProvenanceError("invalid-input-character")
+
+
+def parse_records(text: str) -> Dict[str, str]:
+    if not text.endswith("\n"):
+        raise ProvenanceError("invalid-input-record")
+    lines = text[:-1].split("\n")
+    if not lines or any(not line for line in lines):
+        raise ProvenanceError("invalid-input-record")
+
+    records: Dict[str, str] = {}
+    required = set(REQUIRED_KEYS)
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if not separator or not key or not value or "=" in value:
+            raise ProvenanceError("invalid-input-record")
+        if key not in required:
+            raise ProvenanceError("unexpected-key")
+        if key in records:
+            raise ProvenanceError("duplicate-key")
+        records[key] = value
+
+    if set(records) != required:
+        raise ProvenanceError("missing-key")
+    return records
+
+
+def semver(groups: Sequence[str]) -> str:
+    return ".".join(groups)
+
+
+def validate_records(records: Dict[str, str]) -> None:
+    release_tag = RELEASE_TAG_RE.fullmatch(records["RELEASE_TAG"])
+    release_version = RELEASE_VERSION_RE.fullmatch(records["RELEASE_VERSION"])
+    automation_tag = AUTOMATION_TAG_RE.fullmatch(records["AUTOMATION_TAG"])
+    if release_tag is None or release_version is None or automation_tag is None:
+        raise ProvenanceError("invalid-value")
+
+    tagged_version = semver(release_tag.groups())
+    if records["RELEASE_VERSION"] != tagged_version:
+        raise ProvenanceError("version-mismatch")
+    if semver(automation_tag.groups()[:3]) != tagged_version:
+        raise ProvenanceError("automation-version-mismatch")
+
+    for key in (
+        "TAG_OBJECT_SHA",
+        "SOURCE_SHA",
+        "AUTOMATION_SHA",
+        "AUTOMATION_TAG_OBJECT_SHA",
+    ):
+        if SHA_RE.fullmatch(records[key]) is None:
+            raise ProvenanceError("invalid-value")
+
+
+def canonical_payloads(records: Dict[str, str]) -> Tuple[bytes, bytes]:
+    environment_lines = [f"{key}={records[key]}" for key in REQUIRED_KEYS]
+    step_lines = [f"{key.lower()}={records[key]}" for key in REQUIRED_KEYS]
+    environment = ("\n".join(environment_lines) + "\n").encode("ascii")
+    step_output = ("\n".join(step_lines) + "\n").encode("ascii")
+    return environment, step_output
+
+
+def output_plan(path_value: str, payload: bytes) -> OutputPlan:
+    if not path_value or any(
+        ord(character) < 0x20 or ord(character) > 0x7E
+        for character in path_value
+    ):
+        raise ProvenanceError("unsafe-output-path")
+    path = Path(path_value)
+    if path.name in {"", ".", ".."}:
+        raise ProvenanceError("unsafe-output-path")
+    parent = path.parent
+    try:
+        parent_metadata = parent.stat()
+    except OSError:
+        raise ProvenanceError("unsafe-output-path")
+    if not stat.S_ISDIR(parent_metadata.st_mode):
+        raise ProvenanceError("unsafe-output-path")
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        raise ProvenanceError("unsafe-output-path")
+    else:
+        raise ProvenanceError("output-exists")
+
+    canonical_target = os.path.join(os.path.realpath(parent), path.name)
+    return OutputPlan(
+        target=path,
+        canonical_target=canonical_target,
+        payload=payload,
+    )
+
+
+def unlink_if_present(path: Path) -> bool:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def stage_output(plan: OutputPlan) -> StagedOutput:
+    descriptor = -1
+    temporary_name = ""
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=TEMP_PREFIX,
+            dir=str(plan.target.parent),
+        )
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            descriptor = -1
+            handle.write(plan.payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        metadata = os.stat(temporary_name, follow_symlinks=False)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ProvenanceError("output-write")
+        return StagedOutput(
+            plan=plan,
+            temporary=Path(temporary_name),
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+        )
+    except (OSError, ProvenanceError) as error:
+        cleanup_succeeded = True
+        if temporary_name:
+            cleanup_succeeded = unlink_if_present(Path(temporary_name))
+        if not cleanup_succeeded:
+            raise ProvenanceError("output-rollback")
+        if isinstance(error, ProvenanceError):
+            raise
+        raise ProvenanceError("output-write")
+    finally:
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def cleanup_staged(staged: Sequence[StagedOutput]) -> bool:
+    succeeded = True
+    for item in staged:
+        if not unlink_if_present(item.temporary):
+            succeeded = False
+    return succeeded
+
+
+def rollback_published(published: Sequence[StagedOutput]) -> bool:
+    succeeded = True
+    for item in reversed(published):
+        try:
+            metadata = os.lstat(item.plan.target)
+        except FileNotFoundError:
+            continue
+        except OSError:
+            succeeded = False
+            continue
+        if metadata.st_dev != item.device or metadata.st_ino != item.inode:
+            succeeded = False
+            continue
+        if not unlink_if_present(item.plan.target):
+            succeeded = False
+    return succeeded
+
+
+def publish_outputs(plans: Sequence[OutputPlan]) -> None:
+    staged: List[StagedOutput] = []
+    published: List[StagedOutput] = []
+    try:
+        for plan in plans:
+            staged.append(stage_output(plan))
+        for item in staged:
+            try:
+                os.link(item.temporary, item.plan.target, follow_symlinks=False)
+            except FileExistsError:
+                raise ProvenanceError("output-exists")
+            except OSError:
+                raise ProvenanceError("output-write")
+            published.append(item)
+    except ProvenanceError:
+        rollback_succeeded = rollback_published(published)
+        cleanup_succeeded = cleanup_staged(staged)
+        if not rollback_succeeded or not cleanup_succeeded:
+            raise ProvenanceError("output-rollback")
+        raise
+
+    if not cleanup_staged(staged):
+        if not rollback_published(published):
+            raise ProvenanceError("output-rollback")
+        raise ProvenanceError("output-write")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = SafeArgumentParser(
+        description="Create canonical GitHub release-provenance command files."
+    )
+    parser.add_argument("--input", required=True, help="validated provenance input")
+    parser.add_argument("--github-env", required=True, help="new GitHub environment file")
+    parser.add_argument("--github-output", required=True, help="new step output file")
+    return parser
+
+
+def main() -> int:
+    try:
+        args = build_parser().parse_args()
+        records = parse_records(read_bounded_ascii_file(args.input))
+        validate_records(records)
+        environment, step_output = canonical_payloads(records)
+        environment_plan = output_plan(args.github_env, environment)
+        step_plan = output_plan(args.github_output, step_output)
+        if environment_plan.canonical_target == step_plan.canonical_target:
+            raise ProvenanceError("unsafe-output-path")
+        publish_outputs((environment_plan, step_plan))
+        return 0
+    except ProvenanceError as error:
+        print("parse-release-provenance: " + error.category, file=sys.stderr)
+        return 1
+    except Exception:
+        print("parse-release-provenance: internal-error", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/parse-release-provenance_test.sh
+++ b/scripts/tests/parse-release-provenance_test.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
+helper="$repo_root/scripts/parse-release-provenance.py"
+test_root=$(/usr/bin/mktemp -d \
+  "${TMPDIR:-/tmp}/barrier-release-provenance-test.XXXXXX")
+
+cleanup() {
+  /bin/rm -rf "$test_root"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+fail() {
+  echo "release provenance parser test failed: $1" >&2
+  exit 1
+}
+
+assert_absent() {
+  local path=$1
+  if test -e "$path" || test -L "$path"; then
+    fail 'a rejected case created an output path'
+  fi
+}
+
+assert_no_staging_files() {
+  local directory=$1
+  if /usr/bin/find "$directory" -name '.release-provenance.*' \
+      -print -quit | /usr/bin/grep . >/dev/null; then
+    fail 'a rejected case retained a staging file'
+  fi
+}
+
+write_valid_input() {
+  local path=$1
+  {
+    # Deliberately shuffled: successful output must use canonical key order.
+    printf 'AUTOMATION_TAG_OBJECT_SHA=4444444444444444444444444444444444444444\n'
+    printf 'SOURCE_SHA=2222222222222222222222222222222222222222\n'
+    printf 'RELEASE_VERSION=3.4.0\n'
+    printf 'AUTOMATION_SHA=3333333333333333333333333333333333333333\n'
+    printf 'RELEASE_TAG=v3.4.0\n'
+    printf 'TAG_OBJECT_SHA=1111111111111111111111111111111111111111\n'
+    printf 'AUTOMATION_TAG=v3.4.0-automation.1\n'
+  } >"$path"
+}
+
+expect_rejection() {
+  local label=$1
+  local category=$2
+  local input_path=$3
+  local case_dir="$test_root/rejected-$label"
+  local environment_path="$case_dir/github.env"
+  local output_path="$case_dir/github.output"
+  local stdout_path="$case_dir/stdout"
+  local stderr_path="$case_dir/stderr"
+  /bin/mkdir -p "$case_dir"
+
+  if /usr/bin/python3 "$helper" \
+      --input "$input_path" \
+      --github-env "$environment_path" \
+      --github-output "$output_path" \
+      >"$stdout_path" 2>"$stderr_path"; then
+    fail "$label unexpectedly succeeded"
+  fi
+  test ! -s "$stdout_path" || fail "$label emitted stdout"
+  /usr/bin/grep -Fqx "parse-release-provenance: $category" \
+    "$stderr_path" || fail "$label returned the wrong safe category"
+  assert_absent "$environment_path"
+  assert_absent "$output_path"
+  assert_no_staging_files "$case_dir"
+}
+
+valid_input="$test_root/valid.input"
+write_valid_input "$valid_input"
+success_dir="$test_root/success"
+/bin/mkdir -p "$success_dir"
+success_env="$success_dir/github.env"
+success_output="$success_dir/github.output"
+success_stdout="$success_dir/stdout"
+success_stderr="$success_dir/stderr"
+/usr/bin/python3 "$helper" \
+  --input "$valid_input" \
+  --github-env "$success_env" \
+  --github-output "$success_output" \
+  >"$success_stdout" 2>"$success_stderr"
+test ! -s "$success_stdout" || fail 'success emitted stdout'
+test ! -s "$success_stderr" || fail 'success emitted stderr'
+
+expected_env="$success_dir/expected.env"
+expected_output="$success_dir/expected.output"
+{
+  printf 'RELEASE_TAG=v3.4.0\n'
+  printf 'RELEASE_VERSION=3.4.0\n'
+  printf 'TAG_OBJECT_SHA=1111111111111111111111111111111111111111\n'
+  printf 'SOURCE_SHA=2222222222222222222222222222222222222222\n'
+  printf 'AUTOMATION_SHA=3333333333333333333333333333333333333333\n'
+  printf 'AUTOMATION_TAG=v3.4.0-automation.1\n'
+  printf 'AUTOMATION_TAG_OBJECT_SHA=4444444444444444444444444444444444444444\n'
+} >"$expected_env"
+{
+  printf 'release_tag=v3.4.0\n'
+  printf 'release_version=3.4.0\n'
+  printf 'tag_object_sha=1111111111111111111111111111111111111111\n'
+  printf 'source_sha=2222222222222222222222222222222222222222\n'
+  printf 'automation_sha=3333333333333333333333333333333333333333\n'
+  printf 'automation_tag=v3.4.0-automation.1\n'
+  printf 'automation_tag_object_sha=4444444444444444444444444444444444444444\n'
+} >"$expected_output"
+/usr/bin/cmp -s "$expected_env" "$success_env" \
+  || fail 'environment output is not canonical'
+/usr/bin/cmp -s "$expected_output" "$success_output" \
+  || fail 'step output is not canonical'
+assert_no_staging_files "$success_dir"
+
+duplicate_input="$test_root/duplicate.input"
+/bin/cp "$valid_input" "$duplicate_input"
+printf 'SOURCE_SHA=5555555555555555555555555555555555555555\n' \
+  >>"$duplicate_input"
+expect_rejection duplicate duplicate-key "$duplicate_input"
+
+missing_input="$test_root/missing.input"
+/usr/bin/sed '/^AUTOMATION_TAG_OBJECT_SHA=/d' "$valid_input" >"$missing_input"
+expect_rejection missing missing-key "$missing_input"
+
+extra_input="$test_root/extra.input"
+/bin/cp "$valid_input" "$extra_input"
+printf 'EXTRA=value\n' >>"$extra_input"
+expect_rejection extra unexpected-key "$extra_input"
+
+multiline_input="$test_root/multiline.input"
+/usr/bin/sed '/^AUTOMATION_TAG=/d' "$valid_input" >"$multiline_input"
+{
+  printf 'AUTOMATION_TAG=v3.4.0-automation.1\n'
+  printf 'INJECTED=unsafe\n'
+} >>"$multiline_input"
+expect_rejection multiline unexpected-key "$multiline_input"
+
+unsafe_character_input="$test_root/unsafe-character.input"
+/usr/bin/sed 's/^RELEASE_TAG=.*/RELEASE_TAG=v3.4.0\r/' \
+  "$valid_input" >"$unsafe_character_input"
+expect_rejection unsafe-character invalid-input-character \
+  "$unsafe_character_input"
+
+unterminated_input="$test_root/unterminated.input"
+/usr/bin/sed '$d' "$valid_input" >"$unterminated_input"
+printf 'AUTOMATION_TAG_OBJECT_SHA=4444444444444444444444444444444444444444' \
+  >>"$unterminated_input"
+expect_rejection unterminated invalid-input-record "$unterminated_input"
+
+mismatch_input="$test_root/mismatch.input"
+/usr/bin/sed 's/^RELEASE_VERSION=.*/RELEASE_VERSION=3.4.1/' \
+  "$valid_input" >"$mismatch_input"
+expect_rejection mismatch version-mismatch "$mismatch_input"
+
+automation_mismatch_input="$test_root/automation-mismatch.input"
+/usr/bin/sed \
+  's/^AUTOMATION_TAG=.*/AUTOMATION_TAG=v3.5.0-automation.1/' \
+  "$valid_input" >"$automation_mismatch_input"
+expect_rejection automation-mismatch automation-version-mismatch \
+  "$automation_mismatch_input"
+
+invalid_semver_input="$test_root/invalid-semver.input"
+/usr/bin/sed 's/^RELEASE_TAG=.*/RELEASE_TAG=v03.4.0/' \
+  "$valid_input" >"$invalid_semver_input"
+expect_rejection invalid-semver invalid-value "$invalid_semver_input"
+
+invalid_automation_tag_input="$test_root/invalid-automation-tag.input"
+/usr/bin/sed \
+  's/^AUTOMATION_TAG=.*/AUTOMATION_TAG=v3.4.0-automation.01/' \
+  "$valid_input" >"$invalid_automation_tag_input"
+expect_rejection invalid-automation-tag invalid-value \
+  "$invalid_automation_tag_input"
+
+zero_automation_tag_input="$test_root/zero-automation-tag.input"
+/usr/bin/sed \
+  's/^AUTOMATION_TAG=.*/AUTOMATION_TAG=v3.4.0-automation.0/' \
+  "$valid_input" >"$zero_automation_tag_input"
+expect_rejection zero-automation-tag invalid-value \
+  "$zero_automation_tag_input"
+
+invalid_sha_input="$test_root/invalid-sha.input"
+/usr/bin/sed 's/^SOURCE_SHA=.*/SOURCE_SHA=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/' \
+  "$valid_input" >"$invalid_sha_input"
+expect_rejection invalid-sha invalid-value "$invalid_sha_input"
+
+oversized_input="$test_root/oversized.input"
+/usr/bin/perl -e 'print "A" x 8193' >"$oversized_input"
+expect_rejection oversized invalid-input-size "$oversized_input"
+
+existing_dir="$test_root/existing-output"
+/bin/mkdir -p "$existing_dir"
+existing_env="$existing_dir/github.env"
+existing_step="$existing_dir/github.output"
+printf 'sentinel-env\n' >"$existing_env"
+if /usr/bin/python3 "$helper" \
+    --input "$valid_input" \
+    --github-env "$existing_env" \
+    --github-output "$existing_step" \
+    >"$existing_dir/stdout" 2>"$existing_dir/stderr"; then
+  fail 'existing environment output unexpectedly succeeded'
+fi
+/usr/bin/grep -Fqx 'sentinel-env' "$existing_env" \
+  || fail 'existing environment output was modified'
+assert_absent "$existing_step"
+test ! -s "$existing_dir/stdout" || fail 'existing output failure emitted stdout'
+/usr/bin/grep -Fqx 'parse-release-provenance: output-exists' \
+  "$existing_dir/stderr" || fail 'existing output returned the wrong category'
+assert_no_staging_files "$existing_dir"
+
+existing_second_dir="$test_root/existing-second-output"
+/bin/mkdir -p "$existing_second_dir"
+new_env="$existing_second_dir/github.env"
+existing_step="$existing_second_dir/github.output"
+printf 'sentinel-step\n' >"$existing_step"
+if /usr/bin/python3 "$helper" \
+    --input "$valid_input" \
+    --github-env "$new_env" \
+    --github-output "$existing_step" \
+    >"$existing_second_dir/stdout" 2>"$existing_second_dir/stderr"; then
+  fail 'existing step output unexpectedly succeeded'
+fi
+assert_absent "$new_env"
+/usr/bin/grep -Fqx 'sentinel-step' "$existing_step" \
+  || fail 'existing step output was modified'
+assert_no_staging_files "$existing_second_dir"
+
+symlink_dir="$test_root/symlink-output"
+/bin/mkdir -p "$symlink_dir"
+symlink_target="$symlink_dir/target"
+symlink_env="$symlink_dir/github.env"
+symlink_step="$symlink_dir/github.output"
+printf 'sentinel-target\n' >"$symlink_target"
+/bin/ln -s "$symlink_target" "$symlink_step"
+if /usr/bin/python3 "$helper" \
+    --input "$valid_input" \
+    --github-env "$symlink_env" \
+    --github-output "$symlink_step" \
+    >"$symlink_dir/stdout" 2>"$symlink_dir/stderr"; then
+  fail 'symlink output unexpectedly succeeded'
+fi
+assert_absent "$symlink_env"
+test -L "$symlink_step" || fail 'symlink output was replaced'
+/usr/bin/grep -Fqx 'sentinel-target' "$symlink_target" \
+  || fail 'symlink target was modified'
+assert_no_staging_files "$symlink_dir"
+
+same_path_dir="$test_root/same-output-path"
+/bin/mkdir -p "$same_path_dir"
+same_path="$same_path_dir/github.commands"
+if /usr/bin/python3 "$helper" \
+    --input "$valid_input" \
+    --github-env "$same_path" \
+    --github-output "$same_path" \
+    >"$same_path_dir/stdout" 2>"$same_path_dir/stderr"; then
+  fail 'identical output paths unexpectedly succeeded'
+fi
+assert_absent "$same_path"
+/usr/bin/grep -Fqx 'parse-release-provenance: unsafe-output-path' \
+  "$same_path_dir/stderr" || fail 'identical paths returned the wrong category'
+assert_no_staging_files "$same_path_dir"
+
+printf 'release provenance parser tests passed\n'

--- a/scripts/tests/verify-release-checks_test.sh
+++ b/scripts/tests/verify-release-checks_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
+verifier="$repo_root/scripts/verify-release-checks.sh"
+test_root=$(/usr/bin/mktemp -d \
+    "${TMPDIR:-/tmp}/barrier-release-check-test.XXXXXX")
+
+cleanup() {
+    /bin/rm -rf "$test_root"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+fake_gh="$test_root/gh"
+# The following single-quoted lines are intentionally literal script source.
+# shellcheck disable=SC2016
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'sha=' \
+    'saw_branch=0' \
+    'saw_event=0' \
+    'saw_status=0' \
+    'for argument in "$@"; do' \
+    '  case "$argument" in' \
+    '    head_sha=*) sha=${argument#head_sha=} ;;' \
+    '    branch=main) saw_branch=1 ;;' \
+    '    event=push) saw_event=1 ;;' \
+    '    status=completed) saw_status=1 ;;' \
+    '  esac' \
+    'done' \
+    'test "$saw_branch:$saw_event:$saw_status" = 1:1:1' \
+    'case "${FAKE_SCENARIO:-success}" in' \
+    '  success) printf "%s\tmain\tpush\tcompleted\tsuccess\n" "$sha" ;;' \
+    '  pr) printf "%s\tmain\tpull_request\tcompleted\tsuccess\n" "$sha" ;;' \
+    '  pending) printf "%s\tmain\tpush\tin_progress\t\n" "$sha" ;;' \
+    '  failure) printf "%s\tmain\tpush\tcompleted\tfailure\n" "$sha" ;;' \
+    '  branch) printf "%s\tfeature\tpush\tcompleted\tsuccess\n" "$sha" ;;' \
+    '  wrong-sha) printf "%040d\tmain\tpush\tcompleted\tsuccess\n" 0 ;;' \
+    '  empty) exit 0 ;;' \
+    '  api-failure) exit 1 ;;' \
+    '  *) exit 2 ;;' \
+    'esac' \
+    > "$fake_gh"
+/bin/chmod +x "$fake_gh"
+
+first_sha=1111111111111111111111111111111111111111
+second_sha=2222222222222222222222222222222222222222
+BARRIER_GH_BIN="$fake_gh" "$verifier" \
+    public-owner/public-repo "$first_sha" "$second_sha" >/dev/null
+
+for scenario in pr pending failure branch wrong-sha empty api-failure; do
+    if FAKE_SCENARIO="$scenario" BARRIER_GH_BIN="$fake_gh" \
+        "$verifier" public-owner/public-repo "$first_sha" \
+        > "$test_root/$scenario.stdout" 2> "$test_root/$scenario.stderr"; then
+        echo 'release-check verifier accepted a non-current check' >&2
+        exit 1
+    fi
+done
+
+for invalid_sha in bad 1234 ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ; do
+    if BARRIER_GH_BIN="$fake_gh" \
+        "$verifier" public-owner/public-repo "$invalid_sha" >/dev/null 2>&1; then
+        echo 'release-check verifier accepted an invalid commit' >&2
+        exit 1
+    fi
+done
+
+for invalid_repo in /absolute owner/repo/extra owner@host/repo ''; do
+    if BARRIER_GH_BIN="$fake_gh" \
+        "$verifier" "$invalid_repo" "$first_sha" >/dev/null 2>&1; then
+        echo 'release-check verifier accepted an invalid repository' >&2
+        exit 1
+    fi
+done
+
+printf 'release workflow-run verifier tests passed\n'

--- a/scripts/tests/verify-release-recipe-pair_test.sh
+++ b/scripts/tests/verify-release-recipe-pair_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
+verifier="$repo_root/scripts/verify-release-recipe-pair.py"
+automation_workflow="$repo_root/.github/workflows/release-macos-arm64.yml"
+test_root=$(/usr/bin/mktemp -d \
+    "${TMPDIR:-/tmp}/barrier-recipe-pair-test.XXXXXX")
+
+cleanup() {
+    /bin/rm -rf "$test_root"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+source_workflow="$test_root/source.yml"
+if ! git -C "$repo_root" show \
+    v3.4.0:.github/workflows/release-macos-arm64.yml \
+    > "$source_workflow"; then
+    echo 'unable to prepare tagged release workflow fixture' >&2
+    exit 1
+fi
+
+/usr/bin/python3 "$verifier" \
+    --release-tag v3.4.0 \
+    --source-workflow "$source_workflow" \
+    --automation-workflow "$automation_workflow" >/dev/null
+
+mutated_source="$test_root/mutated-source.yml"
+/bin/cp "$source_workflow" "$mutated_source"
+printf '\n# unknown source field\n' >> "$mutated_source"
+if /usr/bin/python3 "$verifier" \
+    --release-tag v3.4.0 \
+    --source-workflow "$mutated_source" \
+    --automation-workflow "$automation_workflow" >/dev/null 2>&1; then
+    echo 'release-recipe verifier accepted source workflow drift' >&2
+    exit 1
+fi
+
+mutated_automation="$test_root/mutated-automation.yml"
+/bin/cp "$automation_workflow" "$mutated_automation"
+printf '\n# unknown automation field\n' >> "$mutated_automation"
+if /usr/bin/python3 "$verifier" \
+    --release-tag v3.4.0 \
+    --source-workflow "$source_workflow" \
+    --automation-workflow "$mutated_automation" >/dev/null 2>&1; then
+    echo 'release-recipe verifier accepted automation workflow drift' >&2
+    exit 1
+fi
+
+if /usr/bin/python3 "$verifier" \
+    --release-tag v3.4.1 \
+    --source-workflow "$source_workflow" \
+    --automation-workflow "$automation_workflow" >/dev/null 2>&1; then
+    echo 'release-recipe verifier accepted an unaudited tag' >&2
+    exit 1
+fi
+
+if /usr/bin/python3 "$verifier" \
+    --release-tag v3.4.0 \
+    --source-workflow "$test_root/missing.yml" \
+    --automation-workflow "$automation_workflow" >/dev/null 2>&1; then
+    echo 'release-recipe verifier accepted a missing workflow' >&2
+    exit 1
+fi
+
+printf 'release workflow-pair fingerprint tests passed\n'

--- a/scripts/tests/verify-release-tag_test.sh
+++ b/scripts/tests/verify-release-tag_test.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$test_dir/../.." && pwd)
+helper="$repo_root/scripts/verify-release-tag.py"
+test_root=$(/usr/bin/mktemp -d \
+  "${TMPDIR:-/tmp}/barrier-release-tag-test.XXXXXX")
+
+cleanup() {
+    /bin/rm -rf "$test_root"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+export GIT_AUTHOR_NAME='Barrier Release Fixture'
+export GIT_AUTHOR_EMAIL='release-fixture@example.invalid'
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+
+case_number=0
+
+fail() {
+  echo "release tag verifier test failed: $1" >&2
+  exit 1
+}
+
+expect_failure() {
+  local label=$1
+  local category=$2
+  shift 2
+  case_number=$((case_number + 1))
+  local stdout_path="$test_root/failure-$case_number.stdout"
+  local stderr_path="$test_root/failure-$case_number.stderr"
+
+  if "$@" >"$stdout_path" 2>"$stderr_path"; then
+    fail "$label unexpectedly succeeded"
+  fi
+  if test -s "$stdout_path"; then
+    fail "$label emitted stdout"
+  fi
+  if ! /usr/bin/grep -Fqx "verify-release-tag: $category" "$stderr_path"; then
+    fail "$label returned the wrong safe failure category"
+  fi
+}
+
+expect_success() {
+  local label=$1
+  local output_path=$2
+  shift 2
+  local stderr_path="$output_path.stderr"
+
+  if ! "$@" >"$output_path" 2>"$stderr_path"; then
+    /usr/bin/grep -E '^verify-release-tag: [a-z0-9-]+$' \
+      "$stderr_path" >&2 || true
+    fail "$label failed"
+  fi
+  if test -s "$stderr_path"; then
+    fail "$label emitted stderr"
+  fi
+  if /usr/bin/grep -Ev \
+      '^[A-Z][A-Z0-9_]*=[A-Za-z0-9._:/+@-]+$' "$output_path" >/dev/null; then
+    fail "$label emitted an unsafe output record"
+  fi
+}
+
+output_value() {
+  local key=$1
+  local output_path=$2
+  /usr/bin/awk -F= -v key="$key" '$1 == key { print $2 }' "$output_path"
+}
+
+init_work_repo() {
+  local path=$1
+  git init -q -b main "$path"
+}
+
+init_bare_repo() {
+  local path=$1
+  git init -q --bare "$path"
+  git --git-dir="$path" symbolic-ref HEAD refs/heads/main
+}
+
+write_version() {
+  local repo=$1
+  local major=$2
+  local minor=$3
+  local patch=$4
+  /bin/mkdir -p "$repo/cmake"
+  {
+    printf 'cmake_minimum_required (VERSION 3.4)\n\n'
+    printf 'set (BARRIER_VERSION_MAJOR %s)\n' "$major"
+    printf 'set (BARRIER_VERSION_MINOR %s)\n' "$minor"
+    printf 'set (BARRIER_VERSION_PATCH %s)\n' "$patch"
+    printf 'set (BARRIER_VERSION_STAGE "release")\n'
+  } >"$repo/cmake/Version.cmake"
+}
+
+public_submodule_url='https://github.''com/example/barrier-release-fixture.git'
+public_nested_url='https://github.''com/example/barrier-nested-fixture.git'
+unsafe_submodule_url='git''@github.com:example/barrier-release-fixture.git'
+
+# Build a release history with an annotated source tag followed by automation.
+release_remote="$test_root/release-remote.git"
+release_work="$test_root/release-work"
+init_bare_repo "$release_remote"
+init_work_repo "$release_work"
+write_version "$release_work" 1 2 3
+printf 'release source\n' >"$release_work/README.md"
+git -C "$release_work" add cmake/Version.cmake README.md
+git -C "$release_work" commit -q -m 'release source fixture'
+release_source_sha=$(git -C "$release_work" rev-parse HEAD)
+release_version_sha=$(/usr/bin/shasum -a 256 \
+  "$release_work/cmake/Version.cmake" | /usr/bin/awk '{print $1}')
+git -C "$release_work" tag -a v1.2.3 -m 'release 1.2.3' "$release_source_sha"
+printf 'automation only\n' >>"$release_work/README.md"
+git -C "$release_work" add README.md
+git -C "$release_work" commit -q -m 'automation fixture'
+automation_sha=$(git -C "$release_work" rev-parse HEAD)
+automation_tag=v1.2.3-automation.1
+git -C "$release_work" tag -a "$automation_tag" \
+  -m 'release automation 1.2.3' "$automation_sha"
+git -C "$release_work" remote add origin "$release_remote"
+git -C "$release_work" push -q origin main --tags
+automation_tag_object_sha=$(git -C "$release_work" rev-parse "$automation_tag")
+
+resolve_output="$test_root/resolve.out"
+expect_success resolve "$resolve_output" /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" \
+  --remote origin \
+  --release-tag v1.2.3 \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$release_version_sha"
+
+test "$(output_value RELEASE_TAG "$resolve_output")" = v1.2.3 \
+  || fail 'resolve returned the wrong tag'
+test "$(output_value RELEASE_VERSION "$resolve_output")" = 1.2.3 \
+  || fail 'resolve returned the wrong version'
+test "$(output_value SOURCE_SHA "$resolve_output")" = "$release_source_sha" \
+  || fail 'resolve returned the wrong source SHA'
+test "$(output_value AUTOMATION_SHA "$resolve_output")" = "$automation_sha" \
+  || fail 'resolve returned the wrong automation SHA'
+tag_object_sha=$(output_value TAG_OBJECT_SHA "$resolve_output")
+
+recheck_output="$test_root/recheck.out"
+expect_success recheck "$recheck_output" /usr/bin/python3 "$helper" recheck \
+  --repo "$release_work" \
+  --remote origin \
+  --release-tag v1.2.3 \
+  --tag-object-sha "$tag_object_sha" \
+  --source-sha "$release_source_sha" \
+  --automation-tag "$automation_tag" \
+  --automation-tag-object-sha "$automation_tag_object_sha" \
+  --automation-sha "$automation_sha"
+test "$(output_value REMOTE_TAG_STABLE "$recheck_output")" = 1 \
+  || fail 'recheck did not report a stable tag'
+
+# Reject a shell-shaped tag without reflecting or executing it.
+injection_marker="$test_root/injection-marker"
+injection_tag='v1.2.3;to''uch '"$injection_marker"
+expect_failure injection invalid-release-tag /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" \
+  --remote origin \
+  --release-tag "$injection_tag" \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$release_version_sha"
+test ! -e "$injection_marker" || fail 'malformed tag executed as shell input'
+
+# Reject a lightweight tag and a tag whose semantic version differs from source.
+git -C "$release_work" tag v1.2.4 "$release_source_sha"
+git -C "$release_work" push -q origin refs/tags/v1.2.4
+expect_failure lightweight local-annotated-tag /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" --remote origin --release-tag v1.2.4 \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$release_version_sha"
+
+git -C "$release_work" tag -a v9.9.9 -m 'wrong version' "$release_source_sha"
+git -C "$release_work" push -q origin refs/tags/v9.9.9
+expect_failure wrong-version source-version-mismatch \
+  /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" --remote origin --release-tag v9.9.9 \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$release_version_sha"
+
+# The workflow pins the reviewed version file, so textual duplicate,
+# conditional, and bracket-comment decoys cannot alter what is built.
+expect_version_drift_failure() {
+  local label=$1
+  local patch=$2
+  local mutation=$3
+  local work="$test_root/version-drift-$label"
+  local tag="v1.2.$patch"
+  local version_file="$work/cmake/Version.cmake"
+  local original="$work/cmake/Version.original.cmake"
+
+  git clone -q "$release_remote" "$work"
+  git -C "$work" checkout -q --detach "$release_source_sha"
+  write_version "$work" 1 2 "$patch"
+  local reviewed_sha
+  reviewed_sha=$(/usr/bin/shasum -a 256 "$version_file" \
+    | /usr/bin/awk '{print $1}')
+
+  case "$mutation" in
+    duplicate)
+      printf 'set (BARRIER_VERSION_MAJOR 9)\n' >>"$version_file"
+      ;;
+    conditional)
+      /bin/mv "$version_file" "$original"
+      {
+        printf 'if (FALSE)\n'
+        printf '  set (BARRIER_VERSION_MAJOR 1)\n'
+        printf 'endif()\n'
+        /usr/bin/sed \
+          's/^set (BARRIER_VERSION_MAJOR 1)$/set (BARRIER_VERSION_MAJOR 9)/' \
+          "$original"
+      } >"$version_file"
+      ;;
+    comment)
+      /bin/mv "$version_file" "$original"
+      {
+        printf '#[[\n'
+        printf 'set (BARRIER_VERSION_MAJOR 1)\n'
+        printf ']]\n'
+        /usr/bin/sed \
+          's/^set (BARRIER_VERSION_MAJOR 1)$/set (BARRIER_VERSION_MAJOR 9)/' \
+          "$original"
+      } >"$version_file"
+      ;;
+    *)
+      fail 'unknown version drift fixture'
+      ;;
+  esac
+
+  git -C "$work" add cmake/Version.cmake
+  git -C "$work" commit -q -m "version drift $label fixture"
+  git -C "$work" tag -a "$tag" -m "version drift $label"
+  git -C "$work" push -q origin "refs/tags/$tag"
+  git -C "$release_work" fetch -q origin "refs/tags/$tag:refs/tags/$tag"
+  expect_failure "version-$label" source-version-digest \
+    /usr/bin/python3 "$helper" resolve \
+    --repo "$release_work" --remote origin --release-tag "$tag" \
+    --automation-tag "$automation_tag" \
+    --automation-sha "$automation_sha" \
+    --version-file-sha256 "$reviewed_sha"
+}
+
+expect_version_drift_failure duplicate 5 duplicate
+expect_version_drift_failure conditional 6 conditional
+expect_version_drift_failure comment 7 comment
+
+# A correctly versioned side-history tag still cannot be released from main.
+side_work="$test_root/side-work"
+git clone -q --no-checkout "$release_remote" "$side_work"
+git -C "$side_work" checkout -q --orphan side-release
+git -C "$side_work" rm -q -rf .
+write_version "$side_work" 2 0 0
+printf 'side history\n' >"$side_work/README.md"
+git -C "$side_work" add cmake/Version.cmake README.md
+git -C "$side_work" commit -q -m 'side release fixture'
+side_version_sha=$(/usr/bin/shasum -a 256 \
+  "$side_work/cmake/Version.cmake" | /usr/bin/awk '{print $1}')
+git -C "$side_work" tag -a v2.0.0 -m 'side release'
+git -C "$side_work" push -q origin refs/tags/v2.0.0
+git -C "$release_work" fetch -q origin \
+  refs/tags/v2.0.0:refs/tags/v2.0.0
+expect_failure non-main source-ancestry /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" --remote origin --release-tag v2.0.0 \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$side_version_sha"
+
+# Create public-safe nested and top-level submodule repositories.
+nested_remote="$test_root/nested-remote.git"
+nested_work="$test_root/nested-work"
+init_bare_repo "$nested_remote"
+init_work_repo "$nested_work"
+printf 'nested source\n' >"$nested_work/nested.txt"
+git -C "$nested_work" add nested.txt
+git -C "$nested_work" commit -q -m 'nested fixture'
+git -C "$nested_work" remote add origin "$nested_remote"
+git -C "$nested_work" push -q origin main
+
+nested_contact_marker="$test_root/nested-contacted"
+marker_transport="$test_root/marker-transport"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '/usr/bin/touch %q\n' "$nested_contact_marker"
+  printf 'exec git-upload-pack "$%s"\n' 1
+} >"$marker_transport"
+/bin/chmod 700 "$marker_transport"
+unsafe_nested_url="ext::$marker_transport $nested_remote"
+GIT_ALLOW_PROTOCOL=ext git ls-remote "$unsafe_nested_url" >/dev/null
+test -e "$nested_contact_marker" \
+  || fail 'nested marker transport fixture did not execute'
+/bin/rm -f "$nested_contact_marker"
+
+submodule_remote="$test_root/submodule-remote.git"
+submodule_work="$test_root/submodule-work"
+init_bare_repo "$submodule_remote"
+init_work_repo "$submodule_work"
+printf 'submodule source\n' >"$submodule_work/module.txt"
+git -C "$submodule_work" add module.txt
+git -C "$submodule_work" commit -q -m 'submodule fixture'
+submodule_source_sha=$(git -C "$submodule_work" rev-parse HEAD)
+git -C "$submodule_work" remote add origin "$submodule_remote"
+git -C "$submodule_work" push -q origin main
+
+# Preserve a branch whose nested URL is unsafe for the recursive negative path.
+git -C "$submodule_work" switch -q -c unsafe-nested
+git -C "$submodule_work" \
+  -c protocol.file.allow=always \
+  -c "url.file://${nested_remote}.insteadOf=${public_nested_url}" \
+  submodule add -q "$public_nested_url" nested/item
+git -C "$submodule_work" config -f .gitmodules \
+  submodule.nested/item.url "$unsafe_nested_url"
+git -C "$submodule_work" add .gitmodules nested/item
+git -C "$submodule_work" commit -q -m 'unsafe nested URL fixture'
+unsafe_nested_submodule_sha=$(git -C "$submodule_work" rev-parse HEAD)
+git -C "$submodule_work" push -q origin unsafe-nested
+git -C "$submodule_work" switch -q main
+printf 'second submodule commit\n' >>"$submodule_work/module.txt"
+git -C "$submodule_work" add module.txt
+git -C "$submodule_work" commit -q -m 'mismatch fixture'
+submodule_mismatch_sha=$(git -C "$submodule_work" rev-parse HEAD)
+git -C "$submodule_work" push -q origin main
+
+source_remote="$test_root/source-remote.git"
+source_work="$test_root/source-work"
+init_bare_repo "$source_remote"
+init_work_repo "$source_work"
+write_version "$source_work" 3 4 0
+printf 'source checkout fixture\n' >"$source_work/README.md"
+git -C "$source_work" add cmake/Version.cmake README.md
+git -C "$source_work" \
+  -c protocol.file.allow=always \
+  -c "url.file://${submodule_remote}.insteadOf=${public_submodule_url}" \
+  submodule add -q "$public_submodule_url" deps/example
+git -C "$source_work/deps/example" checkout -q "$submodule_source_sha"
+git -C "$source_work" add .gitmodules deps/example
+git -C "$source_work" commit -q -m 'source with public submodule fixture'
+verified_source_sha=$(git -C "$source_work" rev-parse HEAD)
+printf 'later source commit\n' >>"$source_work/README.md"
+git -C "$source_work" add README.md
+git -C "$source_work" commit -q -m 'wrong HEAD fixture'
+wrong_head_sha=$(git -C "$source_work" rev-parse HEAD)
+git -C "$source_work" remote add origin "$source_remote"
+git -C "$source_work" push -q origin main
+
+source_checkout="$test_root/source-checkout"
+git clone -q --no-recurse-submodules "$source_remote" "$source_checkout"
+git -C "$source_checkout" checkout -q --detach "$verified_source_sha"
+
+pre_output="$test_root/pre-init.out"
+expect_success pre-init "$pre_output" /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" \
+  --source-sha "$verified_source_sha" \
+  --phase pre-init
+test "$(output_value SUBMODULE_COUNT "$pre_output")" = 1 \
+  || fail 'pre-init returned the wrong submodule count'
+test "$(output_value SUBMODULE_000_SHA "$pre_output")" = \
+  "$submodule_source_sha" || fail 'pre-init returned the wrong gitlink'
+
+expect_failure missing-submodule submodule-state \
+  /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" --source-sha "$verified_source_sha" \
+  --phase post-init
+
+test_git_config="$test_root/gitconfig"
+git config --file "$test_git_config" protocol.file.allow always
+git config --file "$test_git_config" \
+  "url.file://${submodule_remote}.insteadOf" "$public_submodule_url"
+export GIT_CONFIG_GLOBAL="$test_git_config"
+init_output="$test_root/initialize.out"
+expect_success initialize "$init_output" /usr/bin/python3 "$helper" \
+  initialize-submodules \
+  --source-dir "$source_checkout" \
+  --source-sha "$verified_source_sha"
+test "$(output_value SOURCE_PHASE "$init_output")" = initialized \
+  || fail 'initialize returned the wrong phase'
+test "$(output_value SUBMODULE_COUNT "$init_output")" = 1 \
+  || fail 'initialize returned the wrong recursive submodule count'
+post_output="$test_root/post-init.out"
+expect_success post-init "$post_output" /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" \
+  --source-sha "$verified_source_sha" \
+  --phase post-init
+test "$(output_value SUBMODULE_COUNT "$post_output")" = 1 \
+  || fail 'post-init returned the wrong recursive submodule count'
+
+git -C "$source_checkout" checkout -q --detach "$wrong_head_sha"
+expect_failure wrong-head source-head /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" --source-sha "$verified_source_sha" \
+  --phase pre-init
+git -C "$source_checkout" checkout -q --detach "$verified_source_sha"
+
+printf 'dirty source\n' >"$source_checkout/untracked-fixture.txt"
+expect_failure dirty-source source-dirty /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" --source-sha "$verified_source_sha" \
+  --phase pre-init
+/bin/rm -f "$source_checkout/untracked-fixture.txt"
+
+# A different checked-out commit than the parent gitlink is rejected.
+git -C "$source_checkout/deps/example" fetch -q "$submodule_remote" main
+git -C "$source_checkout/deps/example" checkout -q "$submodule_mismatch_sha"
+expect_failure mismatched-submodule submodule-state \
+  /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" --source-sha "$verified_source_sha" \
+  --phase post-init
+git -C "$source_checkout" submodule update -q --force
+
+# Top-level URL validation runs before submodule initialization.
+git -C "$source_checkout" switch -q -c unsafe-top "$verified_source_sha"
+git -C "$source_checkout" config -f .gitmodules \
+  submodule.deps/example.url "$unsafe_submodule_url"
+git -C "$source_checkout" add .gitmodules
+git -C "$source_checkout" commit -q -m 'unsafe top-level URL fixture'
+unsafe_top_sha=$(git -C "$source_checkout" rev-parse HEAD)
+expect_failure unsafe-top-url submodule-url \
+  /usr/bin/python3 "$helper" verify-source \
+  --source-dir "$source_checkout" --source-sha "$unsafe_top_sha" \
+  --phase pre-init
+
+# A safe top-level entry cannot hide an unsafe nested URL. The one-depth
+# initializer must reject it before Git can invoke the marker transport.
+git -C "$source_checkout" switch -q -C unsafe-nested-source "$verified_source_sha"
+git -C "$source_checkout/deps/example" fetch -q \
+  "$submodule_remote" unsafe-nested
+git -C "$source_checkout/deps/example" checkout -q \
+  "$unsafe_nested_submodule_sha"
+git -C "$source_checkout" add deps/example
+git -C "$source_checkout" commit -q -m 'unsafe nested source fixture'
+unsafe_nested_source_sha=$(git -C "$source_checkout" rev-parse HEAD)
+expect_failure unsafe-nested-url submodule-url \
+  /usr/bin/env GIT_ALLOW_PROTOCOL=file:https:ext \
+  /usr/bin/python3 "$helper" initialize-submodules \
+  --source-dir "$source_checkout" --source-sha "$unsafe_nested_source_sha"
+test ! -e "$nested_contact_marker" \
+  || fail 'unsafe nested transport was contacted before validation'
+
+# Moving either protected remote tag after resolution invalidates the release.
+automation_mover="$test_root/automation-mover"
+git clone -q "$release_remote" "$automation_mover"
+git -C "$automation_mover" tag -f -a "$automation_tag" \
+  -m 'moved automation annotation' "$automation_sha"
+git -C "$automation_mover" push -q --force origin \
+  "refs/tags/$automation_tag"
+expect_failure moved-automation-during-resolve remote-automation-tag-mismatch \
+  /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" --remote origin --release-tag v1.2.3 \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$release_version_sha"
+expect_failure moved-automation-before-upload remote-automation-tag-changed \
+  /usr/bin/python3 "$helper" recheck \
+  --repo "$release_work" --remote origin --release-tag v1.2.3 \
+  --tag-object-sha "$tag_object_sha" --source-sha "$release_source_sha" \
+  --automation-tag "$automation_tag" \
+  --automation-tag-object-sha "$automation_tag_object_sha" \
+  --automation-sha "$automation_sha"
+git -C "$release_work" push -q --force origin \
+  "refs/tags/$automation_tag"
+
+tag_mover="$test_root/tag-mover"
+git clone -q "$release_remote" "$tag_mover"
+git -C "$tag_mover" tag -f -a v1.2.3 -m 'moved annotation' \
+  "$release_source_sha"
+git -C "$tag_mover" push -q --force origin refs/tags/v1.2.3
+expect_failure moved-during-resolve remote-tag-mismatch \
+  /usr/bin/python3 "$helper" resolve \
+  --repo "$release_work" --remote origin --release-tag v1.2.3 \
+  --automation-tag "$automation_tag" \
+  --automation-sha "$automation_sha" \
+  --version-file-sha256 "$release_version_sha"
+expect_failure moved-before-upload remote-tag-changed \
+  /usr/bin/python3 "$helper" recheck \
+  --repo "$release_work" --remote origin --release-tag v1.2.3 \
+  --tag-object-sha "$tag_object_sha" --source-sha "$release_source_sha" \
+  --automation-tag "$automation_tag" \
+  --automation-tag-object-sha "$automation_tag_object_sha" \
+  --automation-sha "$automation_sha"
+
+printf 'release tag verifier tests passed\n'

--- a/scripts/verify-release-checks.sh
+++ b/scripts/verify-release-checks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo 'release-check verification requires a repository and commit' >&2
+    exit 2
+fi
+
+repository=$1
+shift
+case "$repository" in
+    *[!A-Za-z0-9_./-]*|*/*/*|/*|*/|'')
+        echo 'release-check verification received an invalid repository' >&2
+        exit 2
+        ;;
+esac
+
+gh_bin=${BARRIER_GH_BIN:-gh}
+if ! command -v "$gh_bin" >/dev/null 2>&1; then
+    echo 'release-check verification is unavailable' >&2
+    exit 2
+fi
+
+for release_sha in "$@"; do
+    if [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]]; then
+        echo 'release-check verification received an invalid commit' >&2
+        exit 2
+    fi
+    for workflow in ci.yml public-audit.yml; do
+        run_record=
+        if ! run_record=$("$gh_bin" api \
+            "repos/$repository/actions/workflows/$workflow/runs" \
+            --method GET \
+            -f head_sha="$release_sha" \
+            -f branch=main \
+            -f event=push \
+            -f status=completed \
+            -f per_page=20 \
+            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[0] | select(. != null) | [.head_sha, .head_branch, .event, .status, .conclusion] | @tsv' \
+            2>/dev/null); then
+            echo 'release-check query failed' >&2
+            exit 1
+        fi
+        IFS=$'\t' read -r head_sha head_branch event status conclusion \
+            <<< "$run_record"
+        if [ "$head_sha" != "$release_sha" ] \
+            || [ "$head_branch" != main ] \
+            || [ "$event" != push ] \
+            || [ "$status" != completed ] \
+            || [ "$conclusion" != success ]; then
+            echo 'required release check is not a current successful main push' >&2
+            exit 1
+        fi
+    done
+done
+
+printf 'release checks verified\n'

--- a/scripts/verify-release-recipe-pair.py
+++ b/scripts/verify-release-recipe-pair.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+"""Verify the audited one-release workflow pair for immutable v3.4.0.
+
+Version 3.4.0 predates a tag-owned product driver. Its protected product tag
+supplies the original recipe while a separate protected automation tag supplies
+the repaired orchestration. The complete workflow files were compared during
+review and are accepted only as this exact hash pair. Any unknown step, field,
+or command changes a full-file fingerprint and fails closed. Future release
+tags must use a tag-owned driver.
+"""
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+
+SUPPORTED_TAG = "v3.4.0"
+SOURCE_WORKFLOW_SHA256 = "c0f707e5b4d51c4d1a36545c2f681a9a79cdb567dac1a97f4d8dad9dad639601"
+AUTOMATION_WORKFLOW_SHA256 = "cd07cb7fb035b0cedd5fe4925e22296c6fd54636227e86ea7beffa8afe319d72"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+MAX_WORKFLOW_BYTES = 128 * 1024
+
+
+class VerificationError(Exception):
+    pass
+
+
+class SafeArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        del message
+        raise VerificationError
+
+
+def fingerprint(path_text: str) -> str:
+    try:
+        path = Path(path_text)
+        if not path.is_file() or path.is_symlink():
+            raise VerificationError
+        size = path.stat().st_size
+        if size < 1 or size > MAX_WORKFLOW_BYTES:
+            raise VerificationError
+        contents = path.read_bytes()
+    except OSError as error:
+        raise VerificationError from error
+    return hashlib.sha256(contents).hexdigest()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = SafeArgumentParser(add_help=False)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--source-workflow", required=True)
+    parser.add_argument("--automation-workflow", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        if args.release_tag != SUPPORTED_TAG:
+            raise VerificationError
+        if not SHA256_RE.fullmatch(AUTOMATION_WORKFLOW_SHA256):
+            raise VerificationError
+        if fingerprint(args.source_workflow) != SOURCE_WORKFLOW_SHA256:
+            raise VerificationError
+        if fingerprint(args.automation_workflow) != AUTOMATION_WORKFLOW_SHA256:
+            raise VerificationError
+    except VerificationError:
+        print("release-recipe verification failed", file=sys.stderr)
+        return 1
+    except Exception:
+        print("release-recipe verification failed", file=sys.stderr)
+        return 1
+    print("release recipe pair verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-release-tag.py
+++ b/scripts/verify-release-tag.py
@@ -1,0 +1,828 @@
+#!/usr/bin/env python3
+
+"""Fail-closed provenance checks for tag-based release builds.
+
+The workflow uses this helper at three trust transitions:
+
+* ``resolve`` binds an annotated release tag to an immutable tag object and
+  peeled commit while the automation checkout is still the exact remote main.
+* ``verify-source`` checks the separately checked-out source before and after
+  submodule initialization.
+* ``initialize-submodules`` validates each nested URL before initializing that
+  depth, so an unsafe transport is never contacted first.
+* ``recheck`` proves immediately before artifact upload that the remote tag
+  still names the originally resolved objects.
+
+Successful stdout is intentionally limited to validated ``KEY=value`` lines.
+Failures use category-only stderr messages and never echo supplied values.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+TAG_RE = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+AUTOMATION_TAG_RE = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)-automation\.([1-9][0-9]*)$"
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REMOTE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
+PATH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+PUBLIC_GITHUB_URL_RE = re.compile(
+    r"^https://github\.com/[A-Za-z0-9][A-Za-z0-9-]{0,38}/"
+    r"[A-Za-z0-9._-]+(?:\.git)?$"
+)
+OUTPUT_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+MAX_VERSION_FILE_BYTES = 128 * 1024
+MAX_SUBMODULES = 128
+MAX_SUBMODULE_DEPTH = 16
+
+
+class VerificationError(Exception):
+    """A deliberately non-sensitive verification failure."""
+
+    def __init__(self, category: str):
+        super().__init__(category)
+        self.category = category
+
+
+class SafeArgumentParser(argparse.ArgumentParser):
+    """Avoid reflecting malformed arguments into release logs."""
+
+    def error(self, message: str) -> None:
+        del message
+        raise VerificationError("invalid-arguments")
+
+
+@dataclass(frozen=True)
+class SubmoduleRecord:
+    path: str
+    url: str
+    sha: str
+
+
+@dataclass(frozen=True)
+class SubmoduleStatus:
+    state: str
+    sha: str
+
+
+def run_git(
+    repo: Path,
+    args: Sequence[str],
+    allowed_returncodes: Iterable[int] = (0,),
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["LC_ALL"] = "C"
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=45,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        raise VerificationError("git-unavailable")
+    if result.returncode not in set(allowed_returncodes):
+        raise VerificationError("git-command")
+    return result
+
+
+def decode_ascii(data: bytes, category: str) -> str:
+    try:
+        return data.decode("ascii")
+    except UnicodeDecodeError:
+        raise VerificationError(category)
+
+
+def require_sha(value: str, category: str = "invalid-sha") -> str:
+    if not SHA_RE.fullmatch(value):
+        raise VerificationError(category)
+    return value
+
+
+def require_sha256(value: str, category: str = "invalid-sha256") -> str:
+    if not SHA256_RE.fullmatch(value):
+        raise VerificationError(category)
+    return value
+
+
+def parse_release_tag(value: str) -> Tuple[str, str, str, str]:
+    if len(value) > 64:
+        raise VerificationError("invalid-release-tag")
+    match = TAG_RE.fullmatch(value)
+    if match is None:
+        raise VerificationError("invalid-release-tag")
+    major, minor, patch = match.groups()
+    return value, major, minor, patch
+
+
+def parse_automation_tag(value: str) -> Tuple[str, str, str, str, str]:
+    if len(value) > 96:
+        raise VerificationError("invalid-automation-tag")
+    match = AUTOMATION_TAG_RE.fullmatch(value)
+    if match is None:
+        raise VerificationError("invalid-automation-tag")
+    major, minor, patch, sequence = match.groups()
+    return value, major, minor, patch, sequence
+
+
+def require_remote(value: str) -> str:
+    if (
+        not REMOTE_RE.fullmatch(value)
+        or value.startswith("-")
+        or ".." in PurePosixPath(value).parts
+    ):
+        raise VerificationError("invalid-remote")
+    return value
+
+
+def rev_parse(repo: Path, revision: str, category: str) -> str:
+    result = run_git(repo, ["rev-parse", "--verify", revision])
+    value = decode_ascii(result.stdout, category).strip()
+    return require_sha(value, category)
+
+
+def object_type(repo: Path, revision: str, category: str) -> str:
+    result = run_git(repo, ["cat-file", "-t", revision])
+    value = decode_ascii(result.stdout, category).strip()
+    if value not in {"blob", "commit", "tag", "tree"}:
+        raise VerificationError(category)
+    return value
+
+
+def require_worktree(repo: Path, category: str) -> None:
+    result = run_git(repo, ["rev-parse", "--is-inside-work-tree"])
+    if decode_ascii(result.stdout, category).strip() != "true":
+        raise VerificationError(category)
+
+
+def remote_refs(repo: Path, remote: str, refs: Sequence[str]) -> Dict[str, str]:
+    require_remote(remote)
+    result = run_git(repo, ["ls-remote", remote, *refs])
+    output = decode_ascii(result.stdout, "remote-ref")
+    found: Dict[str, str] = {}
+    for line in output.splitlines():
+        fields = line.split("\t")
+        if len(fields) != 2:
+            raise VerificationError("remote-ref")
+        sha, ref = fields
+        require_sha(sha, "remote-ref")
+        if ref not in refs or ref in found:
+            raise VerificationError("remote-ref")
+        found[ref] = sha
+    return found
+
+
+def resolve_local_annotated_tag(
+    repo: Path, tag_name: str, category: str
+) -> Tuple[str, str]:
+    tag_ref = "refs/tags/" + tag_name
+    if object_type(repo, tag_ref, category) != "tag":
+        raise VerificationError(category)
+    tag_object_sha = rev_parse(repo, tag_ref, category)
+    peeled_sha = rev_parse(repo, tag_ref + "^{commit}", category)
+    tag_name_result = run_git(
+        repo, ["for-each-ref", "--format=%(tag)", "--count=1", tag_ref]
+    )
+    if decode_ascii(tag_name_result.stdout, category).strip() != tag_name:
+        raise VerificationError(category)
+    return tag_object_sha, peeled_sha
+
+
+def resolve_remote_tag(
+    repo: Path, remote: str, tag_name: str, category: str = "remote-annotated-tag"
+) -> Tuple[str, str]:
+    tag_ref = "refs/tags/" + tag_name
+    peeled_ref = tag_ref + "^{}"
+    refs = remote_refs(repo, remote, [tag_ref, peeled_ref])
+    if set(refs) != {tag_ref, peeled_ref}:
+        raise VerificationError(category)
+    return refs[tag_ref], refs[peeled_ref]
+
+
+def first_cmake_value(text: str, variable: str, category: str) -> str:
+    pattern = re.compile(
+        r"^[ \t]*set[ \t]*\([ \t]*"
+        + re.escape(variable)
+        + r"[ \t]+(?:\"([^\"\r\n]+)\"|([^\s\)]+))[ \t]*\)",
+        re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise VerificationError(category)
+    return match.group(1) if match.group(1) is not None else match.group(2)
+
+
+def source_version(
+    repo: Path, source_sha: str, expected_file_sha256: str
+) -> Tuple[str, str, str]:
+    expected_digest = require_sha256(
+        expected_file_sha256, "source-version-digest"
+    )
+    result = run_git(repo, ["show", source_sha + ":cmake/Version.cmake"])
+    if (
+        not result.stdout
+        or len(result.stdout) > MAX_VERSION_FILE_BYTES
+        or hashlib.sha256(result.stdout).hexdigest() != expected_digest
+    ):
+        raise VerificationError("source-version-digest")
+    try:
+        text = result.stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        raise VerificationError("source-version")
+    major = first_cmake_value(text, "BARRIER_VERSION_MAJOR", "source-version")
+    minor = first_cmake_value(text, "BARRIER_VERSION_MINOR", "source-version")
+    patch = first_cmake_value(text, "BARRIER_VERSION_PATCH", "source-version")
+    stage = first_cmake_value(text, "BARRIER_VERSION_STAGE", "source-version")
+    for component in (major, minor, patch):
+        if not re.fullmatch(r"0|[1-9][0-9]*", component):
+            raise VerificationError("source-version")
+    if stage != "release":
+        raise VerificationError("source-version")
+    return major, minor, patch
+
+
+def require_clean(repo: Path, category: str) -> None:
+    result = run_git(
+        repo,
+        [
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--ignore-submodules=all",
+        ],
+    )
+    if result.stdout:
+        raise VerificationError(category)
+
+
+def validate_submodule_path(path: str) -> str:
+    if len(path) > 512 or not PATH_RE.fullmatch(path) or "\\" in path:
+        raise VerificationError("submodule-path")
+    pure_path = PurePosixPath(path)
+    if pure_path.is_absolute() or not pure_path.parts:
+        raise VerificationError("submodule-path")
+    if any(part in {"", ".", "..", ".git"} for part in pure_path.parts):
+        raise VerificationError("submodule-path")
+    if str(pure_path) != path:
+        raise VerificationError("submodule-path")
+    return path
+
+
+def validate_submodule_url(url: str) -> str:
+    if len(url) > 512 or not PUBLIC_GITHUB_URL_RE.fullmatch(url):
+        raise VerificationError("submodule-url")
+    return url
+
+
+def gitlinks(repo: Path) -> Dict[str, str]:
+    result = run_git(repo, ["ls-tree", "-r", "-z", "HEAD"])
+    links: Dict[str, str] = {}
+    for raw_entry in result.stdout.split(b"\0"):
+        if not raw_entry:
+            continue
+        header, separator, raw_path = raw_entry.partition(b"\t")
+        if not separator:
+            raise VerificationError("submodule-metadata")
+        fields = header.split(b" ")
+        if len(fields) != 3 or fields[0] != b"160000":
+            continue
+        if fields[1] != b"commit":
+            raise VerificationError("submodule-metadata")
+        try:
+            path = raw_path.decode("utf-8")
+            sha = fields[2].decode("ascii")
+        except UnicodeDecodeError:
+            raise VerificationError("submodule-metadata")
+        validate_submodule_path(path)
+        require_sha(sha, "submodule-metadata")
+        if path in links:
+            raise VerificationError("submodule-metadata")
+        links[path] = sha
+    return links
+
+
+def has_gitmodules(repo: Path) -> bool:
+    result = run_git(repo, ["ls-tree", "-z", "HEAD", "--", ".gitmodules"])
+    if not result.stdout:
+        return False
+    entries = [entry for entry in result.stdout.split(b"\0") if entry]
+    if len(entries) != 1 or not entries[0].startswith(b"100644 blob "):
+        raise VerificationError("submodule-metadata")
+    return True
+
+
+def gitmodule_fields(repo: Path) -> Dict[str, Dict[str, str]]:
+    if not has_gitmodules(repo):
+        return {}
+    result = run_git(
+        repo,
+        [
+            "config",
+            "-z",
+            "--blob",
+            "HEAD:.gitmodules",
+            "--get-regexp",
+            r"^submodule\..*\.(path|url)$",
+        ],
+        allowed_returncodes=(0, 1),
+    )
+    fields: Dict[str, Dict[str, str]] = {}
+    for raw_record in result.stdout.split(b"\0"):
+        if not raw_record:
+            continue
+        raw_key, separator, raw_value = raw_record.partition(b"\n")
+        if not separator:
+            raise VerificationError("submodule-metadata")
+        try:
+            key = raw_key.decode("utf-8")
+            value = raw_value.decode("utf-8")
+        except UnicodeDecodeError:
+            raise VerificationError("submodule-metadata")
+        if not key.startswith("submodule."):
+            raise VerificationError("submodule-metadata")
+        if key.endswith(".path"):
+            name = key[len("submodule.") : -len(".path")]
+            field = "path"
+        elif key.endswith(".url"):
+            name = key[len("submodule.") : -len(".url")]
+            field = "url"
+        else:
+            raise VerificationError("submodule-metadata")
+        if not name or field in fields.setdefault(name, {}):
+            raise VerificationError("submodule-metadata")
+        fields[name][field] = value
+    return fields
+
+
+def direct_submodules(repo: Path) -> List[SubmoduleRecord]:
+    links = gitlinks(repo)
+    fields = gitmodule_fields(repo)
+    records: List[SubmoduleRecord] = []
+    seen_paths = set()
+    for values in fields.values():
+        if set(values) != {"path", "url"}:
+            raise VerificationError("submodule-metadata")
+        path = validate_submodule_path(values["path"])
+        url = validate_submodule_url(values["url"])
+        if path in seen_paths or path not in links:
+            raise VerificationError("submodule-metadata")
+        seen_paths.add(path)
+        records.append(SubmoduleRecord(path=path, url=url, sha=links[path]))
+    if seen_paths != set(links):
+        raise VerificationError("submodule-metadata")
+    return sorted(records, key=lambda record: record.path)
+
+
+def recursive_status(repo: Path) -> Dict[str, SubmoduleStatus]:
+    result = run_git(
+        repo,
+        ["-c", "core.quotePath=false", "submodule", "status", "--recursive"],
+    )
+    statuses: Dict[str, SubmoduleStatus] = {}
+    text = decode_ascii(result.stdout, "submodule-state")
+    for line in text.splitlines():
+        if len(line) < 42:
+            raise VerificationError("submodule-state")
+        state = line[0]
+        remainder = line[1:]
+        sha, separator, path_and_description = remainder.partition(" ")
+        if not separator:
+            raise VerificationError("submodule-state")
+        path = path_and_description.split(" ", 1)[0]
+        require_sha(sha, "submodule-state")
+        validate_submodule_path(path)
+        if state not in {" ", "-", "+", "U"} or path in statuses:
+            raise VerificationError("submodule-state")
+        statuses[path] = SubmoduleStatus(state=state, sha=sha)
+    return statuses
+
+
+def safe_child_directory(source_root: Path, relative_path: str) -> Path:
+    candidate = source_root.joinpath(*PurePosixPath(relative_path).parts)
+    if candidate.is_symlink() or not candidate.is_dir():
+        raise VerificationError("submodule-state")
+    try:
+        candidate.resolve().relative_to(source_root.resolve())
+    except (OSError, ValueError):
+        raise VerificationError("submodule-path")
+    return candidate
+
+
+def verify_recursive_submodules(
+    source_root: Path, top_level: Sequence[SubmoduleRecord]
+) -> List[SubmoduleRecord]:
+    statuses = recursive_status(source_root)
+    visited = set()
+    resolved_records: List[SubmoduleRecord] = []
+
+    def visit(parent: Path, prefix: str, records: Sequence[SubmoduleRecord]) -> None:
+        for record in records:
+            full_path = record.path if not prefix else prefix + "/" + record.path
+            validate_submodule_path(full_path)
+            status = statuses.get(full_path)
+            if status is None or status.state != " " or status.sha != record.sha:
+                raise VerificationError("submodule-state")
+            child = safe_child_directory(source_root, full_path)
+            require_worktree(child, "submodule-state")
+            if rev_parse(child, "HEAD^{commit}", "submodule-state") != record.sha:
+                raise VerificationError("submodule-state")
+            require_clean(child, "submodule-dirty")
+            child_records = direct_submodules(child)
+            visited.add(full_path)
+            resolved_records.append(
+                SubmoduleRecord(path=full_path, url=record.url, sha=record.sha)
+            )
+            visit(child, full_path, child_records)
+
+    visit(source_root, "", top_level)
+    if visited != set(statuses):
+        raise VerificationError("submodule-state")
+    return sorted(resolved_records, key=lambda record: record.path)
+
+
+def initialize_recursive_submodules(
+    source_root: Path, top_level: Sequence[SubmoduleRecord]
+) -> List[SubmoduleRecord]:
+    """Validate each depth before allowing Git to contact the next one."""
+
+    visited = set()
+    resolved_records: List[SubmoduleRecord] = []
+
+    def visit(
+        parent: Path,
+        prefix: str,
+        records: Sequence[SubmoduleRecord],
+        depth: int,
+    ) -> None:
+        if depth > MAX_SUBMODULE_DEPTH:
+            raise VerificationError("submodule-limit")
+        for record in records:
+            if len(visited) >= MAX_SUBMODULES:
+                raise VerificationError("submodule-limit")
+            full_path = record.path if not prefix else prefix + "/" + record.path
+            validate_submodule_path(full_path)
+            if full_path in visited:
+                raise VerificationError("submodule-state")
+
+            # Recursion is explicitly disabled and ``--recursive`` is omitted:
+            # only the URL direct_submodules() already validated is contacted.
+            run_git(
+                parent,
+                [
+                    "-c",
+                    "submodule.recurse=false",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--checkout",
+                    "--",
+                    record.path,
+                ],
+            )
+            child = safe_child_directory(source_root, full_path)
+            require_worktree(child, "submodule-state")
+            if rev_parse(child, "HEAD^{commit}", "submodule-state") != record.sha:
+                raise VerificationError("submodule-state")
+            require_clean(child, "submodule-dirty")
+
+            child_records = direct_submodules(child)
+            visited.add(full_path)
+            resolved_records.append(
+                SubmoduleRecord(path=full_path, url=record.url, sha=record.sha)
+            )
+            visit(child, full_path, child_records, depth + 1)
+
+    visit(source_root, "", top_level, 1)
+    statuses = recursive_status(source_root)
+    if visited != set(statuses):
+        raise VerificationError("submodule-state")
+    expected = {record.path: record.sha for record in resolved_records}
+    for path, status in statuses.items():
+        if status.state != " " or status.sha != expected[path]:
+            raise VerificationError("submodule-state")
+    return sorted(resolved_records, key=lambda record: record.path)
+
+
+def output_pairs(
+    source_sha: str,
+    phase: str,
+    records: Sequence[SubmoduleRecord],
+) -> List[Tuple[str, str]]:
+    pairs: List[Tuple[str, str]] = [
+        ("SOURCE_SHA", source_sha),
+        ("SOURCE_PHASE", phase),
+        ("SUBMODULE_COUNT", str(len(records))),
+    ]
+    for index, record in enumerate(records):
+        prefix = "SUBMODULE_{:03d}_".format(index)
+        pairs.extend(
+            [
+                (prefix + "PATH", record.path),
+                (prefix + "URL", record.url),
+                (prefix + "SHA", record.sha),
+            ]
+        )
+    return pairs
+
+
+def emit(pairs: Sequence[Tuple[str, str]]) -> None:
+    seen = set()
+    lines: List[str] = []
+    for key, value in pairs:
+        if not OUTPUT_KEY_RE.fullmatch(key) or key in seen:
+            raise VerificationError("unsafe-output")
+        if (
+            not value
+            or any(ord(character) < 33 or ord(character) > 126 for character in value)
+            or "=" in value
+        ):
+            raise VerificationError("unsafe-output")
+        seen.add(key)
+        lines.append(key + "=" + value)
+    sys.stdout.write("\n".join(lines) + "\n")
+
+
+def command_resolve(args: argparse.Namespace) -> None:
+    release_tag, tag_major, tag_minor, tag_patch = parse_release_tag(
+        args.release_tag
+    )
+    (
+        automation_tag,
+        automation_major,
+        automation_minor,
+        automation_patch,
+        _,
+    ) = parse_automation_tag(args.automation_tag)
+    automation_sha = require_sha(args.automation_sha)
+    repo = Path(args.repo)
+    require_worktree(repo, "automation-checkout")
+    if rev_parse(repo, "HEAD^{commit}", "automation-checkout") != automation_sha:
+        raise VerificationError("automation-checkout")
+    if object_type(repo, automation_sha, "automation-commit") != "commit":
+        raise VerificationError("automation-commit")
+
+    remote = require_remote(args.remote)
+    main_ref = "refs/heads/main"
+    main_refs = remote_refs(repo, remote, [main_ref])
+    remote_main_sha = main_refs.get(main_ref)
+    if remote_main_sha is None:
+        raise VerificationError("automation-main")
+    main_ancestry = run_git(
+        repo,
+        ["merge-base", "--is-ancestor", automation_sha, remote_main_sha],
+        allowed_returncodes=(0, 1),
+    )
+    if main_ancestry.returncode != 0:
+        raise VerificationError("automation-main")
+
+    tag_object_sha, source_sha = resolve_local_annotated_tag(
+        repo, release_tag, "local-annotated-tag"
+    )
+    remote_tag_object, remote_source = resolve_remote_tag(repo, remote, release_tag)
+    if remote_tag_object != tag_object_sha or remote_source != source_sha:
+        raise VerificationError("remote-tag-mismatch")
+
+    if source_version(
+        repo, source_sha, args.version_file_sha256
+    ) != (tag_major, tag_minor, tag_patch):
+        raise VerificationError("source-version-mismatch")
+    ancestry = run_git(
+        repo,
+        ["merge-base", "--is-ancestor", source_sha, automation_sha],
+        allowed_returncodes=(0, 1),
+    )
+    if ancestry.returncode != 0:
+        raise VerificationError("source-ancestry")
+
+    if (automation_major, automation_minor, automation_patch) != (
+        tag_major,
+        tag_minor,
+        tag_patch,
+    ):
+        raise VerificationError("automation-tag-version")
+    automation_tag_object_sha, automation_tag_commit = (
+        resolve_local_annotated_tag(
+            repo, automation_tag, "local-automation-annotated-tag"
+        )
+    )
+    if automation_tag_commit != automation_sha:
+        raise VerificationError("local-automation-tag-mismatch")
+    remote_automation_object, remote_automation_commit = resolve_remote_tag(
+        repo,
+        remote,
+        automation_tag,
+        "remote-automation-annotated-tag",
+    )
+    if (
+        remote_automation_object != automation_tag_object_sha
+        or remote_automation_commit != automation_sha
+    ):
+        raise VerificationError("remote-automation-tag-mismatch")
+
+    emit(
+        [
+            ("RELEASE_TAG", release_tag),
+            ("RELEASE_VERSION", ".".join((tag_major, tag_minor, tag_patch))),
+            ("TAG_OBJECT_SHA", tag_object_sha),
+            ("SOURCE_SHA", source_sha),
+            ("AUTOMATION_SHA", automation_sha),
+            ("AUTOMATION_TAG", automation_tag),
+            ("AUTOMATION_TAG_OBJECT_SHA", automation_tag_object_sha),
+        ]
+    )
+
+
+def command_verify_source(args: argparse.Namespace) -> None:
+    source_sha = require_sha(args.source_sha)
+    source_dir = Path(args.source_dir)
+    require_worktree(source_dir, "source-checkout")
+    if rev_parse(source_dir, "HEAD^{commit}", "source-checkout") != source_sha:
+        raise VerificationError("source-head")
+    require_clean(source_dir, "source-dirty")
+    top_level = direct_submodules(source_dir)
+    if args.phase == "pre-init":
+        records = top_level
+    elif args.phase == "post-init":
+        records = verify_recursive_submodules(source_dir, top_level)
+    else:
+        raise VerificationError("invalid-arguments")
+    emit(output_pairs(source_sha, args.phase, records))
+
+
+def command_initialize_submodules(args: argparse.Namespace) -> None:
+    source_sha = require_sha(args.source_sha)
+    source_dir = Path(args.source_dir)
+    require_worktree(source_dir, "source-checkout")
+    if rev_parse(source_dir, "HEAD^{commit}", "source-checkout") != source_sha:
+        raise VerificationError("source-head")
+    require_clean(source_dir, "source-dirty")
+    records = initialize_recursive_submodules(
+        source_dir, direct_submodules(source_dir)
+    )
+    require_clean(source_dir, "source-dirty")
+    emit(output_pairs(source_sha, "initialized", records))
+
+
+def command_recheck(args: argparse.Namespace) -> None:
+    release_tag, _, _, _ = parse_release_tag(args.release_tag)
+    automation_tag, _, _, _, _ = parse_automation_tag(args.automation_tag)
+    tag_object_sha = require_sha(args.tag_object_sha)
+    source_sha = require_sha(args.source_sha)
+    automation_sha = require_sha(args.automation_sha)
+    automation_tag_object_sha = require_sha(args.automation_tag_object_sha)
+    repo = Path(args.repo)
+    require_worktree(repo, "automation-checkout")
+    if rev_parse(repo, "HEAD^{commit}", "automation-checkout") != automation_sha:
+        raise VerificationError("automation-checkout")
+    remote = require_remote(args.remote)
+    remote_tag_object, remote_source = resolve_remote_tag(
+        repo, remote, release_tag
+    )
+    if remote_tag_object != tag_object_sha or remote_source != source_sha:
+        raise VerificationError("remote-tag-changed")
+    remote_automation_object, remote_automation_commit = resolve_remote_tag(
+        repo,
+        remote,
+        automation_tag,
+        "remote-automation-annotated-tag",
+    )
+    if (
+        remote_automation_object != automation_tag_object_sha
+        or remote_automation_commit != automation_sha
+    ):
+        raise VerificationError("remote-automation-tag-changed")
+    main_ref = "refs/heads/main"
+    main_refs = remote_refs(repo, remote, [main_ref])
+    remote_main_sha = main_refs.get(main_ref)
+    if remote_main_sha is None:
+        raise VerificationError("automation-main")
+    main_ancestry = run_git(
+        repo,
+        ["merge-base", "--is-ancestor", automation_sha, remote_main_sha],
+        allowed_returncodes=(0, 1),
+    )
+    if main_ancestry.returncode != 0:
+        raise VerificationError("automation-main")
+    emit(
+        [
+            ("RELEASE_TAG", release_tag),
+            ("TAG_OBJECT_SHA", tag_object_sha),
+            ("SOURCE_SHA", source_sha),
+            ("REMOTE_TAG_STABLE", "1"),
+            ("AUTOMATION_TAG", automation_tag),
+            ("AUTOMATION_TAG_OBJECT_SHA", automation_tag_object_sha),
+            ("AUTOMATION_SHA", automation_sha),
+            ("REMOTE_AUTOMATION_TAG_STABLE", "1"),
+        ]
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = SafeArgumentParser(
+        description="Verify immutable release-tag and source provenance."
+    )
+    subparsers = parser.add_subparsers(
+        dest="command", required=True, parser_class=SafeArgumentParser
+    )
+
+    resolve = subparsers.add_parser(
+        "resolve",
+        help="bind an annotated remote tag to a source commit",
+    )
+    resolve.add_argument("--repo", required=True, help="automation checkout")
+    resolve.add_argument("--remote", default="origin", help="safe Git remote name")
+    resolve.add_argument("--release-tag", required=True, help="vMAJOR.MINOR.PATCH")
+    resolve.add_argument(
+        "--automation-tag",
+        required=True,
+        help="vMAJOR.MINOR.PATCH-automation.N",
+    )
+    resolve.add_argument("--automation-sha", required=True, help="exact main SHA")
+    resolve.add_argument(
+        "--version-file-sha256",
+        required=True,
+        help="reviewed cmake/Version.cmake SHA-256",
+    )
+    resolve.set_defaults(handler=command_resolve)
+
+    verify_source = subparsers.add_parser(
+        "verify-source",
+        help="verify source checkout and submodule provenance",
+    )
+    verify_source.add_argument("--source-dir", required=True, help="source checkout")
+    verify_source.add_argument("--source-sha", required=True, help="peeled tag SHA")
+    verify_source.add_argument(
+        "--phase", required=True, choices=("pre-init", "post-init")
+    )
+    verify_source.set_defaults(handler=command_verify_source)
+
+    initialize_submodules = subparsers.add_parser(
+        "initialize-submodules",
+        help="validate and initialize public submodules one depth at a time",
+    )
+    initialize_submodules.add_argument(
+        "--source-dir", required=True, help="source checkout"
+    )
+    initialize_submodules.add_argument(
+        "--source-sha", required=True, help="peeled tag SHA"
+    )
+    initialize_submodules.set_defaults(handler=command_initialize_submodules)
+
+    recheck = subparsers.add_parser(
+        "recheck",
+        help="recheck remote tag objects immediately before upload",
+    )
+    recheck.add_argument("--repo", required=True, help="automation checkout")
+    recheck.add_argument("--remote", default="origin", help="safe Git remote name")
+    recheck.add_argument("--release-tag", required=True, help="vMAJOR.MINOR.PATCH")
+    recheck.add_argument("--tag-object-sha", required=True, help="captured tag object")
+    recheck.add_argument("--source-sha", required=True, help="captured peeled commit")
+    recheck.add_argument(
+        "--automation-tag",
+        required=True,
+        help="captured immutable automation tag",
+    )
+    recheck.add_argument(
+        "--automation-tag-object-sha",
+        required=True,
+        help="captured automation tag object",
+    )
+    recheck.add_argument(
+        "--automation-sha", required=True, help="captured automation commit"
+    )
+    recheck.set_defaults(handler=command_recheck)
+    return parser
+
+
+def main() -> int:
+    try:
+        args = build_parser().parse_args()
+        args.handler(args)
+        return 0
+    except VerificationError as error:
+        print("verify-release-tag: " + error.category, file=sys.stderr)
+        return 1
+    except Exception:
+        print("verify-release-tag: internal-error", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #49

## Summary
- build the 3.4.0 product from the immutable annotated `v3.4.0` source tag
- anchor repaired release automation and every helper to a protected annotated automation tag
- require exact successful main-push CI and public-audit runs for source and automation commits
- validate submodule URLs one depth before access and recheck both tags before upload
- remove unauthenticated dependency-cache restore and build the locked prefix from source
- parse provenance through an exact-set, fail-closed canonicalizer

## Verification
- actionlint and shellcheck
- Python compilation
- provenance parser, tag/submodule, recipe-pair, exact-check, diagnostics, deployment-target, and metadata-scanner tests
- full public-audit fixture suite
- real repository public audit
- two independent adversarial review rounds