### PR TITLE
Explain why Barrier 3.4.0 matters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Silicon fork. Historical entries were reconstructed from audited source
 snapshots and release documentation; see
 [source provenance](docs/history/source-provenance.md).
 
+## Unreleased
+
+### Documentation
+
+- Published the signed and notarized Barrier 3.4.0 Apple Silicon DMG and
+  documented its effective macOS 26.0 binary dependency floor.
+
 ## 3.4.0 — 2026-08-31
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ Silicon fork. Historical entries were reconstructed from audited source
 snapshots and release documentation; see
 [source provenance](docs/history/source-provenance.md).
 
-## Unreleased
-
-### Documentation
-
-- Published the signed and notarized Barrier 3.4.0 Apple Silicon DMG and
-  documented its effective macOS 26.0 binary dependency floor.
-
 ## 3.4.0 — 2026-08-31
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -8,6 +8,30 @@ display-routing behavior, and compatibility fixes for this fork. For general
 Barrier usage, supported platforms, FAQ, source history, and upstream project
 details, see the [upstream Barrier repository](https://github.com/debauchee/barrier).
 
+## Why Barrier 3.4.0?
+
+**Your desk is not always a straight row of screens, and it does not stay the
+same shape. Barrier 3.4.0 is built for that reality.**
+
+[Apple Universal Control](https://support.apple.com/guide/mac-help/mchl412faecf/mac)
+is convenient when nearby Macs and iPads use the same Apple Account. Barrier
+3.4.0 tackles a different class of setup: several physical displays, a server
+Mac that moves between desks, monitor combinations that change when you dock or
+close a lid, client displays that should be allowed to sleep, and existing
+Windows or Linux machines that still run Legacy Barrier.
+
+| Real-world setup | What Barrier 3.4.0 does | Why it matters |
+| --- | --- | --- |
+| Screens form an L-shape or meet along only part of an edge | Models supported macOS displays as real rectangles and routes between modern fork peers through the edge segments that physically touch | The pointer crosses where the monitors meet instead of treating a multi-display Mac as one large rectangle |
+| The server Mac travels with you | An opt-in macOS client watches for its explicitly paired server using configurable Bluetooth signal thresholds, matching Bonjour identity, and topology readiness | Take the server away and the client waits; bring that server back nearby and the normal Barrier connection can resume automatically |
+| Docking, closing the lid, or attaching external monitors changes the server layout | Lets you save one freeform Barrier profile for each exact server display topology, then selects the matching saved profile automatically | Create each layout once instead of rearranging Barrier every time; an unknown layout pauses switching rather than sending the pointer to the wrong screen |
+| An unused client display goes to sleep | Wakes a connected macOS client display when the pointer enters; an offline Mac can also receive a best-effort Bonjour network-wake request when **Wake for network access** is enabled | Barrier does not need every client display kept bright all day just to remain useful |
+| The desk includes older Windows, Linux, or macOS Barrier peers | Negotiates Legacy Barrier 2.4-compatible protocol behavior while modern 3.x peers retain enhanced display geometry | Keep the machines you already use instead of requiring an all-Apple desk or a simultaneous upgrade |
+
+Universal Control may already cover a fixed Mac-and-iPad desk. Barrier 3.4.0 is
+for the desk that changes shape, crosses operating systems, or needs explicit
+control over when and where machines connect.
+
 ## Download
 
 - Use [GitHub Releases](https://github.com/ibetterai/barrier/releases) to view
@@ -17,7 +41,7 @@ details, see the [upstream Barrier repository](https://github.com/debauchee/barr
   [feature and fix ledger](docs/history/feature-fix-ledger.md) for the
   reconstructed public product history.
 
-The published Barrier 3.4.0 binary targets Apple Silicon and has an effective
+The published Barrier binary targets Apple Silicon and has an effective
 macOS 26.0 minimum because of its bundled dependencies. Before attaching a
 future DMG, verify every bundled Mach-O deployment target together with its
 Developer ID signature, Apple notarization ticket, stapling, and offline

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ details, see the [upstream Barrier repository](https://github.com/debauchee/barr
   [feature and fix ledger](docs/history/feature-fix-ledger.md) for the
   reconstructed public product history.
 
-Release candidates for Barrier 3.4.0 and later target Apple Silicon and macOS
-12 or later. Before attaching a DMG, verify its Developer ID signature, Apple
-notarization ticket, stapling, and offline Gatekeeper acceptance.
+The published Barrier 3.4.0 binary targets Apple Silicon and has an effective
+macOS 26.0 minimum because of its bundled dependencies. Before attaching a
+future DMG, verify every bundled Mach-O deployment target together with its
+Developer ID signature, Apple notarization ticket, stapling, and offline
+Gatekeeper acceptance.
 
 ## What this fork adds
 

--- a/doc/release_notes/index.md
+++ b/doc/release_notes/index.md
@@ -6,6 +6,42 @@ Release notes
 Barrier `3.4.0` ( `2026-08-31` )
 ================================
 
+Why this release matters
+------------------------
+
+**Barrier 3.4.0 makes the pointer follow the physical desk, even when the desk
+changes shape.**
+
+[Apple Universal Control](https://support.apple.com/guide/mac-help/mchl412faecf/mac)
+is designed for nearby Macs and iPads using the same Apple Account. Barrier
+3.4.0 is aimed at changing multi-monitor desks and mixed-platform setups. The
+complete 3.4.0 experience brings together these capabilities:
+
+- **Real L-shaped and partial-edge routing.** Modern fork peers exchange the
+  physical rectangles of their macOS displays, so the pointer crosses the
+  actual shared edge instead of a machine-sized bounding box.
+- **A server Mac that can leave and return.** An opt-in macOS client can wait
+  for its explicitly paired server, then reconnect when that server is nearby,
+  its matching Bonjour service is reachable, and its display topology is ready.
+  Connect and Departure thresholds are configurable for each pairing.
+- **The right layout for the monitors that are connected now.** Save a profile
+  once for each server display combination. After docking, undocking, opening
+  or closing the lid, or changing external monitors, Barrier selects the exact
+  matching profile automatically. An unknown arrangement pauses switching and
+  asks to be saved instead of guessing.
+- **Displays that can sleep when they are not being used.** Barrier wakes a
+  connected macOS client display when the pointer enters. For an offline Mac,
+  it can also request a best-effort Bonjour network wake when **Wake for network
+  access** is enabled, without pretending that Bluetooth alone can wake a Mac.
+- **A path forward without abandoning Legacy Barrier.** Barrier 3.4.0 restores
+  protocol interoperability with Barrier 2.4 and earlier peers, including
+  existing Windows and Linux machines. Legacy peers use rectangular fallback;
+  modern fork peers keep the enhanced geometry.
+
+These are the user-facing capabilities available in 3.4.0, not a claim that
+every item first appeared in this point release. The chronological 3.2, 3.3,
+and 3.4 sections below preserve when each feature or fix was delivered.
+
 Features
 --------
 


### PR DESCRIPTION
## Summary

- explain why Barrier 3.4.0 is useful for changing multi-monitor desks and mixed-platform setups
- highlight real L-shaped routing, paired-server proximity, automatic saved-profile selection, display sleep/wake, and Legacy Barrier interoperability
- preserve the chronological release history and state the published Apple Silicon compatibility floor
- keep private build and deployment details out of public documentation

## Verification

- `git diff --check`
- targeted public-content privacy scan
- documentation claims checked against the implemented behavior and existing specifications
- documentation only: no application, DMG, or release-asset changes

Closes #53
Closes #55