### PR TITLE
Tag-owned release driver: audit v3.4.6 recipe #66

### DIFF
--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 180
     env:
-      AUTOMATION_TAG: v3.4.0-automation.2
+      AUTOMATION_TAG: v3.4.6-automation.1
       RELEASE_PREFIX: /tmp/barrier-release-prefix
       RELEASE_WORK_DIR: /tmp/barrier-release-work
       RELEASE_BUILD_DIR: /tmp/barrier-release-build
@@ -66,7 +66,7 @@ jobs:
             --automation-tag "$AUTOMATION_TAG" \
             --automation-sha "$GITHUB_SHA" \
             --version-file-sha256 \
-              7b496edf4f4f626f6f9da9069b40437181a7121e3e342df4b0965c3096f63e98 \
+              08f90d18ffefcad192136b84a35f306c0be995dd01e53b20c71894be6d286ced \
             >"$provenance_file"
           canonical_env="$RUNNER_TEMP/release-source.github-env"
           canonical_output="$RUNNER_TEMP/release-source.github-output"

--- a/scripts/tests/verify-release-recipe-pair_test.sh
+++ b/scripts/tests/verify-release-recipe-pair_test.sh
@@ -22,10 +22,21 @@ if ! git -C "$repo_root" show \
     exit 1
 fi
 
+# The v3.4.0 automation side is the reviewed post-#52 workflow, pinned from
+# the v3.4.1 tree (byte-identical to the audited file, unlike the working
+# tree once a newer driver lands).
+automation_workflow_340="$test_root/automation-340.yml"
+if ! git -C "$repo_root" show \
+    v3.4.1:.github/workflows/release-macos-arm64.yml \
+    > "$automation_workflow_340"; then
+    echo 'unable to prepare v3.4.0 automation workflow fixture' >&2
+    exit 1
+fi
+
 /usr/bin/python3 "$verifier" \
     --release-tag v3.4.0 \
     --source-workflow "$source_workflow" \
-    --automation-workflow "$automation_workflow" >/dev/null
+    --automation-workflow "$automation_workflow_340" >/dev/null
 
 mutated_source="$test_root/mutated-source.yml"
 /bin/cp "$source_workflow" "$mutated_source"
@@ -33,13 +44,13 @@ printf '\n# unknown source field\n' >> "$mutated_source"
 if /usr/bin/python3 "$verifier" \
     --release-tag v3.4.0 \
     --source-workflow "$mutated_source" \
-    --automation-workflow "$automation_workflow" >/dev/null 2>&1; then
+    --automation-workflow "$automation_workflow_340" >/dev/null 2>&1; then
     echo 'release-recipe verifier accepted source workflow drift' >&2
     exit 1
 fi
 
 mutated_automation="$test_root/mutated-automation.yml"
-/bin/cp "$automation_workflow" "$mutated_automation"
+/bin/cp "$automation_workflow_340" "$mutated_automation"
 printf '\n# unknown automation field\n' >> "$mutated_automation"
 if /usr/bin/python3 "$verifier" \
     --release-tag v3.4.0 \
@@ -52,15 +63,39 @@ fi
 if /usr/bin/python3 "$verifier" \
     --release-tag v3.4.1 \
     --source-workflow "$source_workflow" \
-    --automation-workflow "$automation_workflow" >/dev/null 2>&1; then
+    --automation-workflow "$automation_workflow_340" >/dev/null 2>&1; then
     echo 'release-recipe verifier accepted an unaudited tag' >&2
+    exit 1
+fi
+
+source_workflow_346="$test_root/source-346.yml"
+if ! git -C "$repo_root" show \
+    v3.4.6:.github/workflows/release-macos-arm64.yml \
+    > "$source_workflow_346"; then
+    echo 'unable to prepare v3.4.6 tagged release workflow fixture' >&2
+    exit 1
+fi
+
+/usr/bin/python3 "$verifier" \
+    --release-tag v3.4.6 \
+    --source-workflow "$source_workflow_346" \
+    --automation-workflow "$automation_workflow" >/dev/null
+
+mutated_automation_346="$test_root/mutated-automation-346.yml"
+/bin/cp "$automation_workflow" "$mutated_automation_346"
+printf '\n# unknown automation field\n' >> "$mutated_automation_346"
+if /usr/bin/python3 "$verifier" \
+    --release-tag v3.4.6 \
+    --source-workflow "$source_workflow_346" \
+    --automation-workflow "$mutated_automation_346" >/dev/null 2>&1; then
+    echo 'release-recipe verifier accepted automation workflow drift' >&2
     exit 1
 fi
 
 if /usr/bin/python3 "$verifier" \
     --release-tag v3.4.0 \
     --source-workflow "$test_root/missing.yml" \
-    --automation-workflow "$automation_workflow" >/dev/null 2>&1; then
+    --automation-workflow "$automation_workflow_340" >/dev/null 2>&1; then
     echo 'release-recipe verifier accepted a missing workflow' >&2
     exit 1
 fi

--- a/scripts/verify-release-recipe-pair.py
+++ b/scripts/verify-release-recipe-pair.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
-"""Verify the audited one-release workflow pair for immutable v3.4.0.
+"""Verify an audited release workflow pair for an immutable product tag.
 
-Version 3.4.0 predates a tag-owned product driver. Its protected product tag
-supplies the original recipe while a separate protected automation tag supplies
-the repaired orchestration. The complete workflow files were compared during
-review and are accepted only as this exact hash pair. Any unknown step, field,
-or command changes a full-file fingerprint and fails closed. Future release
-tags must use a tag-owned driver.
+Each supported product tag owns its driver: the exact (source, automation)
+workflow-file fingerprint pair that built it. v3.4.0 predates this table and
+keeps its original pair. Adding a release means adding one audited row; any
+unknown tag, unknown step, field, or command changes a fingerprint and fails
+closed.
 """
 
 import argparse
@@ -16,11 +15,26 @@ import re
 import sys
 from pathlib import Path
 
-
-SUPPORTED_TAG = "v3.4.0"
-SOURCE_WORKFLOW_SHA256 = "c0f707e5b4d51c4d1a36545c2f681a9a79cdb567dac1a97f4d8dad9dad639601"
-AUTOMATION_WORKFLOW_SHA256 = "4cbff406f667d099e3608c88c05262ae6b7dec144570f92a992630bafe36c74b"
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# Audited (source workflow, automation workflow) fingerprint pairs by product
+# tag. The source workflow is the file committed at the product tag; the
+# automation workflow is the file in the automation-tag tree that ran the
+# build. Both trees are immutable and reviewed before tagging.
+RECIPES = {
+    "v3.4.0": {
+        "source_workflow_sha256":
+            "c0f707e5b4d51c4d1a36545c2f681a9a79cdb567dac1a97f4d8dad9dad639601",
+        "automation_workflow_sha256":
+            "4cbff406f667d099e3608c88c05262ae6b7dec144570f92a992630bafe36c74b",
+    },
+    "v3.4.6": {
+        "source_workflow_sha256":
+            "4cbff406f667d099e3608c88c05262ae6b7dec144570f92a992630bafe36c74b",
+        "automation_workflow_sha256":
+            "1cac12cb71accb97018d896cf260d9df5df61cecc99f6b50c676b6c05541adc2",
+    },
+}
 MAX_WORKFLOW_BYTES = 128 * 1024
 
 
@@ -59,13 +73,16 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     try:
         args = parse_args()
-        if args.release_tag != SUPPORTED_TAG:
+        recipe = RECIPES.get(args.release_tag)
+        if recipe is None:
             raise VerificationError
-        if not SHA256_RE.fullmatch(AUTOMATION_WORKFLOW_SHA256):
+        for key in ("source_workflow_sha256",
+                    "automation_workflow_sha256"):
+            if not SHA256_RE.fullmatch(recipe[key]):
+                raise VerificationError
+        if fingerprint(args.source_workflow) != recipe["source_workflow_sha256"]:
             raise VerificationError
-        if fingerprint(args.source_workflow) != SOURCE_WORKFLOW_SHA256:
-            raise VerificationError
-        if fingerprint(args.automation_workflow) != AUTOMATION_WORKFLOW_SHA256:
+        if fingerprint(args.automation_workflow) != recipe["automation_workflow_sha256"]:
             raise VerificationError
     except VerificationError:
         print("release-recipe verification failed", file=sys.stderr)


### PR DESCRIPTION
Part of #66. The release pipeline only accepted v3.4.0 by construction (hardcoded tag + workflow fingerprints). This adds the audited v3.4.6 row instead of special-casing around it: source workflow pinned from the v3.4.6 tag tree, automation workflow pinned to this file, automation tag v3.4.6-automation.1, version digest pinned to 3.4.6. v3.4.0 behavior is byte-identical; unknown tags still fail closed. Recipe-pair tests extended (v3.4.6 pair verifies, drift rejected, unaudited tags rejected); v3.4.0 automation fixture pinned to the v3.4.1 tree instead of the moving working tree.